### PR TITLE
ADH-7362: added method to get JAVA_HOME from env

### DIFF
--- a/docs/layouts/shortcodes/generated/environment_configuration.html
+++ b/docs/layouts/shortcodes/generated/environment_configuration.html
@@ -39,6 +39,12 @@
             <td>A string of default JVM options to prepend to <code class="highlighter-rouge">env.java.opts.taskmanager</code>. This is intended to be set by administrators.</td>
         </tr>
         <tr>
+            <td><h5>env.java.home</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Location where Java is installed. If not specified, Flink will use your default Java installation.</td>
+        </tr>
+        <tr>
             <td><h5>env.java.opts.all</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -1740,6 +1740,8 @@ public final class ConfigConstants {
 
     // ----------------------------- Environment Variables ----------------------------
 
+    public static final String ENV_JAVA_HOME = "JAVA_HOME";
+
     /** The environment variable name which contains the location of the configuration directory. */
     public static final String ENV_FLINK_CONF_DIR = "FLINK_CONF_DIR";
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
@@ -39,6 +39,7 @@ import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.configuration.ConfigConstants.ENV_JAVA_HOME;
 import static org.apache.flink.configuration.MetricOptions.SYSTEM_RESOURCE_METRICS;
 import static org.apache.flink.configuration.MetricOptions.SYSTEM_RESOURCE_METRICS_PROBING_INTERVAL;
 import static org.apache.flink.configuration.StructuredOptionsSplitter.escapeWithSingleQuote;
@@ -663,6 +664,29 @@ public class ConfigurationUtils {
     public static boolean filterPrefixMapKey(String key, String candidate) {
         final String prefixKey = key + ".";
         return candidate.startsWith(prefixKey);
+    }
+
+    /**
+     * Set the JAVA_HOME variable in the provided environment map.
+     *
+     * <p>This method follows a specific priority order to determine the JAVA_HOME value:
+     *
+     * <ol>
+     *   <li>If the environment map already contains the JAVA_HOME key, the method does nothing.
+     *   <li>Otherwise, it attempts to retrieve JAVA_HOME from the Flink configuration using {@link
+     *       CoreOptions#FLINK_JAVA_HOME}.
+     *   <li>If it isn't found in configuration, it falls back to the system environment variable.
+     *   <li>If a value is found through either source, it is added to the environment map.
+     * </ol>
+     */
+    public static void setJavaHomeEnv(Configuration configuration, Map<String, String> env) {
+        if (!env.containsKey(ENV_JAVA_HOME)) {
+            Optional.ofNullable(
+                            configuration
+                                    .getOptional(CoreOptions.FLINK_JAVA_HOME)
+                                    .orElse(System.getenv(ENV_JAVA_HOME)))
+                    .ifPresent(javaHomeStr -> env.put(ENV_JAVA_HOME, javaHomeStr));
+        }
     }
 
     static Map<String, String> convertToPropertiesPrefixed(

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -225,6 +225,17 @@ public class CoreOptions {
     //  process parameters
     // ------------------------------------------------------------------------
 
+    public static final ConfigOption<String> FLINK_JAVA_HOME =
+            ConfigOptions.key("env.java.home")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Location where Java is installed. If not specified,"
+                                                    + " Flink will use your default Java installation.")
+                                    .build());
+
     public static final ConfigOption<String> FLINK_JVM_OPTIONS =
             ConfigOptions.key("env.java.opts.all")
                     .stringType()

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/ContaineredTaskManagerParameters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/ContaineredTaskManagerParameters.java
@@ -19,10 +19,13 @@
 package org.apache.flink.runtime.clusterframework;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.ResourceManagerOptions;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.apache.flink.configuration.ConfigConstants.ENV_JAVA_HOME;
 
 /** This class describes the basic parameters for launching a TaskManager process. */
 public class ContaineredTaskManagerParameters implements java.io.Serializable {
@@ -89,6 +92,10 @@ public class ContaineredTaskManagerParameters implements java.io.Serializable {
                 envVars.put(envVarKey, config.getString(key, null));
             }
         }
+
+        // set JAVA_HOME
+        config.getOptional(CoreOptions.FLINK_JAVA_HOME)
+                .ifPresent(javaHome -> envVars.put(ENV_JAVA_HOME, javaHome));
 
         // done
         return new ContaineredTaskManagerParameters(taskExecutorProcessSpec, envVars);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/ContaineredTaskManagerParameters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/ContaineredTaskManagerParameters.java
@@ -19,13 +19,11 @@
 package org.apache.flink.runtime.clusterframework;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.ResourceManagerOptions;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.apache.flink.configuration.ConfigConstants.ENV_JAVA_HOME;
 
 /** This class describes the basic parameters for launching a TaskManager process. */
 public class ContaineredTaskManagerParameters implements java.io.Serializable {
@@ -94,8 +92,7 @@ public class ContaineredTaskManagerParameters implements java.io.Serializable {
         }
 
         // set JAVA_HOME
-        config.getOptional(CoreOptions.FLINK_JAVA_HOME)
-                .ifPresent(javaHome -> envVars.put(ENV_JAVA_HOME, javaHome));
+        ConfigurationUtils.setJavaHomeEnv(config, envVars);
 
         // done
         return new ContaineredTaskManagerParameters(taskExecutorProcessSpec, envVars);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -137,6 +137,7 @@ import static org.apache.flink.client.deployment.application.ApplicationConfigur
 import static org.apache.flink.configuration.ConfigConstants.DEFAULT_FLINK_USR_LIB_DIR;
 import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_LIB_DIR;
 import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_OPT_DIR;
+import static org.apache.flink.configuration.ConfigConstants.ENV_JAVA_HOME;
 import static org.apache.flink.configuration.ResourceManagerOptions.CONTAINERIZED_MASTER_ENV_PREFIX;
 import static org.apache.flink.configuration.ResourceManagerOptions.CONTAINERIZED_TASK_MANAGER_ENV_PREFIX;
 import static org.apache.flink.runtime.entrypoint.component.FileJobGraphRetriever.JOB_GRAPH_FILE_PATH;
@@ -1969,6 +1970,10 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
                 ConfigurationUtils.getPrefixedKeyValuePairs(
                         ResourceManagerOptions.CONTAINERIZED_MASTER_ENV_PREFIX,
                         this.flinkConfiguration));
+        // set JAVA_HOME
+        this.flinkConfiguration
+                .getOptional(CoreOptions.FLINK_JAVA_HOME)
+                .ifPresent(javaHome -> env.put(ENV_JAVA_HOME, javaHome));
         // set Flink app class path
         env.put(ENV_FLINK_CLASSPATH, classPathStr);
         // Set FLINK_LIB_DIR to `lib` folder under working dir in container

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -137,7 +137,6 @@ import static org.apache.flink.client.deployment.application.ApplicationConfigur
 import static org.apache.flink.configuration.ConfigConstants.DEFAULT_FLINK_USR_LIB_DIR;
 import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_LIB_DIR;
 import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_OPT_DIR;
-import static org.apache.flink.configuration.ConfigConstants.ENV_JAVA_HOME;
 import static org.apache.flink.configuration.ResourceManagerOptions.CONTAINERIZED_MASTER_ENV_PREFIX;
 import static org.apache.flink.configuration.ResourceManagerOptions.CONTAINERIZED_TASK_MANAGER_ENV_PREFIX;
 import static org.apache.flink.runtime.entrypoint.component.FileJobGraphRetriever.JOB_GRAPH_FILE_PATH;
@@ -1970,10 +1969,9 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
                 ConfigurationUtils.getPrefixedKeyValuePairs(
                         ResourceManagerOptions.CONTAINERIZED_MASTER_ENV_PREFIX,
                         this.flinkConfiguration));
+
         // set JAVA_HOME
-        this.flinkConfiguration
-                .getOptional(CoreOptions.FLINK_JAVA_HOME)
-                .ifPresent(javaHome -> env.put(ENV_JAVA_HOME, javaHome));
+        ConfigurationUtils.setJavaHomeEnv(this.flinkConfiguration, env);
         // set Flink app class path
         env.put(ENV_FLINK_CLASSPATH, classPathStr);
         // Set FLINK_LIB_DIR to `lib` folder under working dir in container

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/UtilsTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/UtilsTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
@@ -691,13 +692,36 @@ class UtilsTest {
     }
 
     @Test
+    void testGetTaskManagerEnvsWithEnvJavaHomeSet() {
+        final Configuration cfg = new Configuration();
+        final String newJavaHome = "/usr/lib/jvm/java-openjdk-17";
+        final Map<String, String> oldEnv = System.getenv();
+        try {
+            Map<String, String> newEnv = new HashMap<>(System.getenv());
+            newEnv.put(ConfigConstants.ENV_JAVA_HOME, newJavaHome);
+            CommonTestUtils.setEnv(newEnv);
+
+            cfg.setString(CONTAINERIZED_TASK_MANAGER_ENV_PREFIX + "key", "val");
+            final ContaineredTaskManagerParameters containeredParams =
+                    ContaineredTaskManagerParameters.create(cfg, TASK_EXECUTOR_PROCESS_SPEC);
+            final Map<String, String> envVars = containeredParams.taskManagerEnv();
+            assertThat(envVars)
+                    .containsEntry(ENV_JAVA_HOME, newJavaHome)
+                    .containsEntry("key", "val");
+        } finally {
+            CommonTestUtils.setEnv(oldEnv);
+        }
+    }
+
+    @Test
     void testGetTaskManagerEnvsWithoutJavaHomeSet() {
         final Configuration cfg = new Configuration();
+        final String origJavaHome = System.getenv(ConfigConstants.ENV_JAVA_HOME);
         cfg.setString(CONTAINERIZED_TASK_MANAGER_ENV_PREFIX + "key", "val");
         final ContaineredTaskManagerParameters containeredParams =
                 ContaineredTaskManagerParameters.create(cfg, TASK_EXECUTOR_PROCESS_SPEC);
         final Map<String, String> envVars = containeredParams.taskManagerEnv();
-        assertThat(envVars).doesNotContainKey(ENV_JAVA_HOME);
+        assertThat(envVars.get(ConfigConstants.ENV_JAVA_HOME)).isEqualTo(origJavaHome);
     }
 
     private static void verifyUnitResourceVariousSchedulers(

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -921,11 +921,14 @@ class YarnClusterDescriptorTest {
         final String fakeLocalFlinkJar = "./lib/flink_dist.jar";
         final String fakeClassPath = fakeLocalFlinkJar + ":./usrlib/user.jar";
         final ApplicationId appId = ApplicationId.newInstance(0, 0);
+        final Configuration flinkConfig = new Configuration();
+        flinkConfig.set(CoreOptions.FLINK_JAVA_HOME, "/opt/jdk");
         final Map<String, String> masterEnv =
                 getTestMasterEnv(
-                        new Configuration(), flinkHomeDir, fakeClassPath, fakeLocalFlinkJar, appId);
+                        flinkConfig, flinkHomeDir, fakeClassPath, fakeLocalFlinkJar, appId);
 
         assertThat(masterEnv)
+                .containsEntry(ConfigConstants.ENV_JAVA_HOME, "/opt/jdk")
                 .containsEntry(ConfigConstants.ENV_FLINK_LIB_DIR, "./lib")
                 .containsEntry(YarnConfigKeys.ENV_APP_ID, appId.toString())
                 .containsEntry(
@@ -938,6 +941,20 @@ class YarnClusterDescriptorTest {
         assertThat(masterEnv)
                 .containsEntry(YarnConfigKeys.FLINK_DIST_JAR, fakeLocalFlinkJar)
                 .containsEntry(YarnConfigKeys.ENV_CLIENT_HOME_DIR, flinkHomeDir.getPath());
+    }
+
+    @Test
+    public void testContainerEnvJavaHomeNotOverriddenByDefault(@TempDir File flinkHomeDir)
+            throws IOException {
+        final Configuration flinkConfig = new Configuration();
+        final Map<String, String> masterEnv =
+                getTestMasterEnv(
+                        flinkConfig,
+                        flinkHomeDir,
+                        "",
+                        "./lib/flink_dist.jar",
+                        ApplicationId.newInstance(0, 0));
+        assertThat(masterEnv).doesNotContainKey(ConfigConstants.ENV_JAVA_HOME);
     }
 
     @Test

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -947,6 +947,7 @@ class YarnClusterDescriptorTest {
     public void testContainerEnvJavaHomeNotOverriddenByDefault(@TempDir File flinkHomeDir)
             throws IOException {
         final Configuration flinkConfig = new Configuration();
+        final String origJavaHome = System.getenv(ConfigConstants.ENV_JAVA_HOME);
         final Map<String, String> masterEnv =
                 getTestMasterEnv(
                         flinkConfig,
@@ -954,7 +955,30 @@ class YarnClusterDescriptorTest {
                         "",
                         "./lib/flink_dist.jar",
                         ApplicationId.newInstance(0, 0));
-        assertThat(masterEnv).doesNotContainKey(ConfigConstants.ENV_JAVA_HOME);
+        assertThat(masterEnv.get(ConfigConstants.ENV_JAVA_HOME)).isEqualTo(origJavaHome);
+    }
+
+    @Test
+    public void testContainerEnvJavaHomeNewValue(@TempDir File flinkHomeDir) throws IOException {
+        final Configuration flinkConfig = new Configuration();
+        final String newJavaHome = "/usr/lib/jvm/java-openjdk-17";
+        final Map<String, String> oldEnv = System.getenv();
+
+        try {
+            Map<String, String> newEnv = new HashMap<>(System.getenv());
+            newEnv.put(ConfigConstants.ENV_JAVA_HOME, newJavaHome);
+            CommonTestUtils.setEnv(newEnv);
+            final Map<String, String> masterEnv =
+                    getTestMasterEnv(
+                            flinkConfig,
+                            flinkHomeDir,
+                            "",
+                            "./lib/flink_dist.jar",
+                            ApplicationId.newInstance(0, 0));
+            assertThat(masterEnv.get(ConfigConstants.ENV_JAVA_HOME)).isEqualTo(newJavaHome);
+        } finally {
+            CommonTestUtils.setEnv(oldEnv);
+        }
     }
 
     @Test


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
