### PR TITLE
ADH-7564: Add SPNEGO authentication for JobManager Web UI

### DIFF
--- a/docs/content/docs/deployment/config.md
+++ b/docs/content/docs/deployment/config.md
@@ -161,10 +161,13 @@ You can configure checkpointing directly in code within your Flink job or applic
 
 **Web UI**
 
+  - `web.authentication.type`: Controls authentication for the JobManager Web UI and REST endpoint *(NONE by default)*. Set this to `KERBEROS` to require SPNEGO authentication on all `8081` paths.
   - `web.submit.enable`: Enables uploading and starting jobs through the Flink UI *(true by default)*. Please note that even when this is disabled, session clusters still accept jobs through REST requests (HTTP calls). This flag only guards the feature to upload jobs in the UI.
   - `web.cancel.enable`: Enables canceling jobs through the Flink UI *(true by default)*. Please note that even when this is disabled, session clusters still cancel jobs through REST requests (HTTP calls). This flag only guards the feature to cancel jobs in the UI.
   - `web.upload.dir`: The directory where to store uploaded jobs. Only used when `web.submit.enable` is true.
   - `web.exception-history-size`: Sets the size of the exception history that prints the most recent failures that were handled by Flink for a job.
+
+Exposing the JobManager Web UI / REST endpoint to an untrusted network without authentication allows unauthenticated job submission and control operations. Enable `web.authentication.type: KERBEROS` or place the endpoint behind an authenticated proxy before exposing port `8081`.
 
 **Other**
 

--- a/docs/content/docs/deployment/security/security-kerberos.md
+++ b/docs/content/docs/deployment/security/security-kerberos.md
@@ -60,6 +60,7 @@ The following services and connectors are supported for Kerberos authentication:
 - HDFS
 - HBase
 - ZooKeeper
+- JobManager Web UI / REST endpoint (SPNEGO)
 
 Note that it is possible to enable the use of Kerberos independently for each service or connector.
 For example, the user may enable Hadoop security without necessitating the use of Kerberos for ZooKeeper,
@@ -91,6 +92,34 @@ dynamic entries provided by this module.
 ### ZooKeeper Security Module
 This module configures certain process-wide ZooKeeper security-related settings, namely the ZooKeeper service name (default: `zookeeper`)
 and the JAAS login context name (default: `Client`).
+
+### JobManager Web UI SPNEGO Authentication
+
+The JobManager Web UI and REST endpoint are unauthenticated by default. If port `8081` is reachable from an untrusted network, unauthenticated users can submit jobs and perform control operations. To require Kerberos/SPNEGO authentication on all JobManager WebMonitor paths, enable:
+
+```yaml
+web.authentication.type: KERBEROS
+web.authentication.kerberos.principal: HTTP/_HOST@EXAMPLE.COM
+web.authentication.kerberos.keytab: /etc/security/keytabs/flink-jobmanager-http.keytab
+web.authentication.kerberos.name-rules: DEFAULT
+web.authentication.token.validity: 10 h
+web.authentication.cookie.path: /
+web.authentication.signature.secret-file: /etc/flink/jobmanager-web-auth-secret
+```
+
+The principal must start with `HTTP/`. The `_HOST` placeholder is replaced from `rest.address`, then `rest.bind-address`, then the local canonical hostname. Use `*` to accept all `HTTP/` principals present in the configured keytab.
+
+When enabled, requests without a valid authentication cookie or `Authorization: Negotiate` header receive `401` with `WWW-Authenticate: Negotiate`; malformed or invalid SPNEGO tokens receive `403`. A successful SPNEGO exchange issues a signed `hadoop.auth` cookie, so subsequent requests do not need to negotiate Kerberos again until the cookie expires.
+
+Clients with Kerberos credentials can access the endpoint with:
+
+```bash
+curl --negotiate -u : http://jobmanager.example.com:8081/jobs
+```
+
+For multiple JobManager instances behind the same address, configure a shared `web.authentication.signature.secret` or `web.authentication.signature.secret-file`; otherwise each process uses a random local signing secret and cannot verify cookies issued by another process.
+
+SPNEGO authenticates the caller only. It does not add per-user authorization, user or group allowlists, Ranger policy enforcement, Knox integration, session ownership enforcement, or built-in Flink CLI / REST client SPNEGO support.
 
 ## Deployment Modes
 Here is some information specific to each deployment mode.  

--- a/docs/layouts/shortcodes/generated/web_configuration.html
+++ b/docs/layouts/shortcodes/generated/web_configuration.html
@@ -15,6 +15,54 @@
             <td>Access-Control-Allow-Origin header for all responses from the web-frontend.</td>
         </tr>
         <tr>
+            <td><h5>web.authentication.cookie.path</h5></td>
+            <td style="word-wrap: break-word;">"/"</td>
+            <td>String</td>
+            <td>Cookie path for JobManager web SPNEGO authentication cookies.</td>
+        </tr>
+        <tr>
+            <td><h5>web.authentication.kerberos.keytab</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Absolute path to the keytab file for the JobManager web SPNEGO principal. Required when JobManager web authentication type is KERBEROS.</td>
+        </tr>
+        <tr>
+            <td><h5>web.authentication.kerberos.name-rules</h5></td>
+            <td style="word-wrap: break-word;">"DEFAULT"</td>
+            <td>String</td>
+            <td>Kerberos auth-to-local rules used to map authenticated principals to local user names.</td>
+        </tr>
+        <tr>
+            <td><h5>web.authentication.kerberos.principal</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Kerberos principal for JobManager web SPNEGO authentication. Required when JobManager web authentication type is KERBEROS. The principal must start with HTTP/. The _HOST placeholder is replaced with the configured REST address. Use * to accept all HTTP principals in the keytab.</td>
+        </tr>
+        <tr>
+            <td><h5>web.authentication.signature.secret</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Shared secret for signing JobManager web SPNEGO authentication cookies. If neither this option nor the secret-file option is set, a random process-local secret is generated. Configure the same secret for all JobManager instances that should accept each other's authentication cookies.</td>
+        </tr>
+        <tr>
+            <td><h5>web.authentication.signature.secret-file</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>File containing the shared secret for signing JobManager web SPNEGO authentication cookies. Configure the same secret file for all JobManager instances that should accept each other's authentication cookies.</td>
+        </tr>
+        <tr>
+            <td><h5>web.authentication.token.validity</h5></td>
+            <td style="word-wrap: break-word;">10 h</td>
+            <td>Duration</td>
+            <td>Validity period for JobManager web SPNEGO authentication cookies.</td>
+        </tr>
+        <tr>
+            <td><h5>web.authentication.type</h5></td>
+            <td style="word-wrap: break-word;">NONE</td>
+            <td><p>Enum</p></td>
+            <td>Authentication type for the JobManager web frontend and REST endpoints.<br /><br />Possible values:<ul><li>"NONE"</li><li>"KERBEROS"</li></ul></td>
+        </tr>
+        <tr>
             <td><h5>web.cancel.enable</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/WebOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/WebOptions.java
@@ -123,6 +123,85 @@ public class WebOptions {
                     .withDescription(
                             "Flag indicating whether jobs can be rescaled from the web-frontend.");
 
+    /** Authentication type for the JobManager web-frontend. */
+    public static final ConfigOption<WebAuthenticationType> AUTHENTICATION_TYPE =
+            key("web.authentication.type")
+                    .enumType(WebAuthenticationType.class)
+                    .defaultValue(WebAuthenticationType.NONE)
+                    .withDescription(
+                            "Authentication type for the JobManager web frontend and REST "
+                                    + "endpoints.");
+
+    /** Kerberos principal for JobManager web SPNEGO authentication. */
+    public static final ConfigOption<String> AUTHENTICATION_KERBEROS_PRINCIPAL =
+            key("web.authentication.kerberos.principal")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Kerberos principal for JobManager web SPNEGO authentication. "
+                                    + "Required when JobManager web authentication type is "
+                                    + "KERBEROS. The principal must start with HTTP/. The _HOST "
+                                    + "placeholder is replaced with the configured REST address. "
+                                    + "Use * to accept all HTTP principals in the keytab.");
+
+    /** Kerberos keytab for JobManager web SPNEGO authentication. */
+    public static final ConfigOption<String> AUTHENTICATION_KERBEROS_KEYTAB =
+            key("web.authentication.kerberos.keytab")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Absolute path to the keytab file for the JobManager web SPNEGO "
+                                    + "principal. Required when JobManager web authentication "
+                                    + "type is KERBEROS.");
+
+    /** Kerberos auth-to-local rules for JobManager web SPNEGO authentication. */
+    public static final ConfigOption<String> AUTHENTICATION_KERBEROS_NAME_RULES =
+            key("web.authentication.kerberos.name-rules")
+                    .stringType()
+                    .defaultValue("DEFAULT")
+                    .withDescription(
+                            "Kerberos auth-to-local rules used to map authenticated principals to "
+                                    + "local user names.");
+
+    /** Validity of JobManager web authentication tokens. */
+    public static final ConfigOption<Duration> AUTHENTICATION_TOKEN_VALIDITY =
+            key("web.authentication.token.validity")
+                    .durationType()
+                    .defaultValue(Duration.ofHours(10))
+                    .withDescription(
+                            "Validity period for JobManager web SPNEGO authentication cookies.");
+
+    /** Cookie path for JobManager web authentication tokens. */
+    public static final ConfigOption<String> AUTHENTICATION_COOKIE_PATH =
+            key("web.authentication.cookie.path")
+                    .stringType()
+                    .defaultValue("/")
+                    .withDescription(
+                            "Cookie path for JobManager web SPNEGO authentication cookies.");
+
+    /** Shared signing secret for JobManager web authentication tokens. */
+    public static final ConfigOption<String> AUTHENTICATION_SIGNATURE_SECRET =
+            key("web.authentication.signature.secret")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Shared secret for signing JobManager web SPNEGO authentication "
+                                    + "cookies. If neither this option nor the secret-file option "
+                                    + "is set, a random process-local secret is generated. "
+                                    + "Configure the same secret for all JobManager instances "
+                                    + "that should accept each other's authentication cookies.");
+
+    /** File containing the shared signing secret for JobManager web authentication tokens. */
+    public static final ConfigOption<String> AUTHENTICATION_SIGNATURE_SECRET_FILE =
+            key("web.authentication.signature.secret-file")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "File containing the shared secret for signing JobManager web SPNEGO "
+                                    + "authentication cookies. Configure the same secret file for "
+                                    + "all JobManager instances that should accept each other's "
+                                    + "authentication cookies.");
+
     /** Config parameter defining the number of checkpoints to remember for recent history. */
     public static final ConfigOption<Integer> CHECKPOINTS_HISTORY_SIZE =
             key("web.checkpoints.history")
@@ -152,4 +231,13 @@ public class WebOptions {
 
     /** Not meant to be instantiated. */
     private WebOptions() {}
+
+    /** Authentication types supported by the JobManager web-frontend. */
+    public enum WebAuthenticationType {
+        /** Authentication is disabled. */
+        NONE,
+
+        /** Kerberos/SPNEGO authentication. */
+        KERBEROS
+    }
 }

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -695,7 +695,7 @@ under the License.
 								<excludes>
 									<!-- log4j 2 is bundled separately from the flink-dist jar -->
 									<exclude>org.apache.logging.log4j:*</exclude>
-									<!-- Bundled and relocated inside flink-runtime-web for SPNEGO support. -->
+									<!-- Bundled and relocated inside runtime modules for SPNEGO support. -->
 									<exclude>org.apache.hadoop:hadoop-auth</exclude>
 									<exclude>org.apache.hadoop.thirdparty:hadoop-shaded-guava</exclude>
 								</excludes>

--- a/flink-dist/src/main/resources/config.yaml
+++ b/flink-dist/src/main/resources/config.yaml
@@ -186,6 +186,24 @@ rest:
   # bind-port: 8080-8090
 
 # web:
+#   authentication:
+#     # Optional Kerberos/SPNEGO authentication for the JobManager Web UI and
+#     # REST endpoint on port 8081. The default authentication type is NONE.
+#     # Exposing this endpoint without authentication allows unauthenticated job
+#     # submission and control operations.
+#     type: KERBEROS
+#     kerberos:
+#       principal: HTTP/_HOST@EXAMPLE.COM
+#       keytab: /etc/security/keytabs/flink-jobmanager-http.keytab
+#       # name-rules: DEFAULT
+#     token:
+#       validity: 10 h
+#     cookie:
+#       path: /
+#     signature:
+#       # Configure the same secret file for all JobManager instances that
+#       # should accept each other's authentication cookies.
+#       secret-file: /etc/flink/jobmanager-web-auth-secret
 #   submit:
 #     # Flag to specify whether job submission is enabled from the web-based
 #     # runtime monitor. Uncomment to disable.

--- a/flink-runtime-web/web-dashboard/src/app/app.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/app.component.ts
@@ -96,11 +96,9 @@ export class AppComponent {
     private httpClient: HttpClient,
     private configService: ConfigService
   ) {
-    this.authenticatedUser$ = this.historyServerEnv
-      ? this.httpClient.get<AuthenticatedUser>(`${this.configService.BASE_URL}/auth/user`).pipe(
-          catchError(() => of({ authenticated: false })),
-          shareReplay({ bufferSize: 1, refCount: true })
-        )
-      : of({ authenticated: false });
+    this.authenticatedUser$ = this.httpClient.get<AuthenticatedUser>(`${this.configService.BASE_URL}/auth/user`).pipe(
+      catchError(() => of({ authenticated: false })),
+      shareReplay({ bufferSize: 1, refCount: true })
+    );
   }
 }

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -172,6 +172,47 @@ under the License.
 			</exclusions>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-auth</artifactId>
+			<version>${flink.hadoop.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
+			<exclusions>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>ch.qos.reload4j</groupId>
+					<artifactId>reload4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-reload4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.dropwizard.metrics</groupId>
+					<artifactId>metrics-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.zookeeper</groupId>
+					<artifactId>zookeeper</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.curator</groupId>
+					<artifactId>curator-framework</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.netty</groupId>
+					<artifactId>netty-handler</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
 		<!-- jcip-annotations was previously a transitive dep from hadoop-common but dropped in Hadoop 3.4+ -->
 		<dependency>
 			<groupId>net.jcip</groupId>
@@ -326,6 +367,31 @@ under the License.
 			<artifactId>mockito-subclass</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-minikdc</artifactId>
+			<version>${minikdc.version}</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>ch.qos.reload4j</groupId>
+					<artifactId>reload4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-reload4j</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -434,8 +500,20 @@ under the License.
 						</goals>
 						<configuration>
 							<artifactSet>
-								<includes>
+								<includes combine.children="append">
 									<include>io.airlift:aircompressor</include>
+									<include>org.apache.hadoop:hadoop-auth</include>
+									<include>commons-codec:commons-codec</include>
+									<include>org.apache.httpcomponents:httpclient</include>
+									<include>org.apache.httpcomponents:httpcore</include>
+									<include>org.apache.hadoop.thirdparty:hadoop-shaded-guava</include>
+									<include>org.apache.kerby:kerb-core</include>
+									<include>org.apache.kerby:kerby-pkix</include>
+									<include>org.apache.kerby:kerby-asn1</include>
+									<include>org.apache.kerby:kerby-util</include>
+									<include>org.apache.kerby:kerb-util</include>
+									<include>org.apache.kerby:kerby-config</include>
+									<include>org.apache.kerby:kerb-crypto</include>
 								</includes>
 							</artifactSet>
 							<relocations>
@@ -443,6 +521,18 @@ under the License.
 									<pattern>io.airlift.compress</pattern>
 									<shadedPattern>
 										org.apache.flink.shaded.io.airlift.compress
+									</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.apache.hadoop.security.authentication</pattern>
+									<shadedPattern>
+										org.apache.flink.runtime.shaded.org.apache.hadoop.security.authentication
+									</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.apache.hadoop.thirdparty</pattern>
+									<shadedPattern>
+										org.apache.flink.runtime.shaded.org.apache.hadoop.thirdparty
 									</shadedPattern>
 								</relocation>
 							</relocations>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
@@ -170,6 +170,15 @@ public abstract class RestServerEndpoint implements RestService {
             initializeHandlers(final CompletableFuture<String> localAddressFuture);
 
     /**
+     * Creates endpoint-specific Netty handlers that run after request aggregation and before
+     * service-loaded inbound handlers and routing.
+     */
+    protected Collection<ChannelHandler> createEndpointSpecificChannelHandlers()
+            throws ConfigurationException {
+        return Collections.emptyList();
+    }
+
+    /**
      * Starts this REST server endpoint.
      *
      * @throws Exception if we cannot start the RestServerEndpoint
@@ -225,6 +234,11 @@ public abstract class RestServerEndpoint implements RestService {
                                     .addLast(
                                             new FlinkHttpObjectAggregator(
                                                     maxContentLength, responseHeaders));
+
+                            for (ChannelHandler channelHandler :
+                                    createEndpointSpecificChannelHandlers()) {
+                                ch.pipeline().addLast(channelHandler);
+                            }
 
                             for (InboundChannelHandlerFactory factory :
                                     inboundChannelHandlerFactories) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -166,6 +166,9 @@ import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
 import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.runtime.webmonitor.security.JobManagerAuthenticatedUserHandler;
+import org.apache.flink.runtime.webmonitor.security.JobManagerAuthenticatedUserHeaders;
+import org.apache.flink.runtime.webmonitor.security.JobManagerWebAuthenticationHandler;
 import org.apache.flink.runtime.webmonitor.threadinfo.ThreadInfoRequestCoordinator;
 import org.apache.flink.runtime.webmonitor.threadinfo.VertexThreadInfoTracker;
 import org.apache.flink.runtime.webmonitor.threadinfo.VertexThreadInfoTrackerBuilder;
@@ -179,6 +182,7 @@ import org.apache.flink.util.concurrent.FutureUtils;
 
 import org.apache.flink.shaded.guava33.com.google.common.cache.Cache;
 import org.apache.flink.shaded.guava33.com.google.common.cache.CacheBuilder;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandler;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandler;
 
 import javax.annotation.Nullable;
@@ -228,6 +232,9 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 
     private final Collection<JsonArchivist> archivingHandlers = new ArrayList<>(16);
 
+    private final Optional<JobManagerWebAuthenticationHandler.Factory>
+            webAuthenticationHandlerFactory;
+
     @Nullable private ScheduledFuture<?> executionGraphCleanupTask;
 
     public WebMonitorEndpoint(
@@ -264,6 +271,17 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 
         this.leaderElection = Preconditions.checkNotNull(leaderElection);
         this.fatalErrorHandler = Preconditions.checkNotNull(fatalErrorHandler);
+        this.webAuthenticationHandlerFactory =
+                JobManagerWebAuthenticationHandler.createFactory(
+                        this.clusterConfiguration, responseHeaders);
+    }
+
+    @Override
+    protected Collection<ChannelHandler> createEndpointSpecificChannelHandlers() {
+        return webAuthenticationHandlerFactory
+                .<Collection<ChannelHandler>>map(
+                        factory -> Collections.singletonList(factory.createHandler()))
+                .orElseGet(Collections::emptyList);
     }
 
     private VertexThreadInfoTracker initializeThreadInfoTracker(ScheduledExecutorService executor) {
@@ -319,6 +337,9 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
                         hasWebSubmissionHandlers,
                         restConfiguration.isWebCancelEnabled(),
                         restConfiguration.isWebRescaleEnabled());
+
+        JobManagerAuthenticatedUserHandler authenticatedUserHandler =
+                new JobManagerAuthenticatedUserHandler();
 
         JobIdsHandler jobIdsHandler =
                 new JobIdsHandler(
@@ -750,6 +771,10 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
                         jobManagerJobEnvironmentHandler.getMessageHeaders(),
                         jobManagerJobEnvironmentHandler));
         handlers.add(Tuple2.of(dashboardConfigHandler.getMessageHeaders(), dashboardConfigHandler));
+        handlers.add(
+                Tuple2.of(
+                        JobManagerAuthenticatedUserHeaders.getInstance(),
+                        authenticatedUserHandler));
         handlers.add(Tuple2.of(jobIdsHandler.getMessageHeaders(), jobIdsHandler));
         handlers.add(Tuple2.of(jobStatusHandler.getMessageHeaders(), jobStatusHandler));
         handlers.add(Tuple2.of(jobsOverviewHandler.getMessageHeaders(), jobsOverviewHandler));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/security/JobManagerAuthenticatedUser.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/security/JobManagerAuthenticatedUser.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.webmonitor.security;
+
+import org.apache.flink.util.Preconditions;
+
+/** Authenticated JobManager web user for a single HTTP request. */
+public final class JobManagerAuthenticatedUser {
+
+    private final String userName;
+    private final String principal;
+    private final String type;
+
+    JobManagerAuthenticatedUser(String userName, String principal, String type) {
+        this.userName = Preconditions.checkNotNull(userName);
+        this.principal = Preconditions.checkNotNull(principal);
+        this.type = Preconditions.checkNotNull(type);
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public String getPrincipal() {
+        return principal;
+    }
+
+    public String getType() {
+        return type;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/security/JobManagerAuthenticatedUserHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/security/JobManagerAuthenticatedUserHandler.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.webmonitor.security;
+
+import org.apache.flink.runtime.rest.handler.router.RoutedRequest;
+import org.apache.flink.runtime.rest.handler.util.HandlerUtils;
+import org.apache.flink.runtime.rest.messages.ResponseBody;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandler;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
+import org.apache.flink.shaded.netty4.io.netty.channel.SimpleChannelInboundHandler;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpHeaderNames;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import javax.annotation.Nullable;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/** Handler for exposing the current JobManager web user to the dashboard. */
+@ChannelHandler.Sharable
+public final class JobManagerAuthenticatedUserHandler
+        extends SimpleChannelInboundHandler<RoutedRequest<Object>> {
+
+    private static final Map<String, String> NO_STORE_HEADERS = createNoStoreHeaders();
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, RoutedRequest<Object> routedRequest) {
+        JobManagerAuthenticatedUserResponseBody response =
+                JobManagerWebAuthenticationHandler.getAuthenticatedUser(ctx)
+                        .map(JobManagerAuthenticatedUserResponseBody::authenticated)
+                        .orElseGet(JobManagerAuthenticatedUserResponseBody::unauthenticated);
+
+        HandlerUtils.sendResponse(
+                ctx, routedRequest.getRequest(), response, HttpResponseStatus.OK, NO_STORE_HEADERS);
+    }
+
+    private static Map<String, String> createNoStoreHeaders() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(HttpHeaderNames.CACHE_CONTROL.toString(), "no-store");
+        headers.put(HttpHeaderNames.PRAGMA.toString(), "no-cache");
+        return Collections.unmodifiableMap(headers);
+    }
+
+    /** Response body for the current authenticated JobManager web user. */
+    public static final class JobManagerAuthenticatedUserResponseBody implements ResponseBody {
+
+        public static final String FIELD_NAME_AUTHENTICATED = "authenticated";
+        public static final String FIELD_NAME_USER = "user";
+        public static final String FIELD_NAME_PRINCIPAL = "principal";
+        public static final String FIELD_NAME_TYPE = "type";
+
+        @JsonProperty(FIELD_NAME_AUTHENTICATED)
+        private final boolean authenticated;
+
+        @JsonProperty(FIELD_NAME_USER)
+        @Nullable
+        private final String user;
+
+        @JsonProperty(FIELD_NAME_PRINCIPAL)
+        @Nullable
+        private final String principal;
+
+        @JsonProperty(FIELD_NAME_TYPE)
+        @Nullable
+        private final String type;
+
+        @JsonCreator
+        public JobManagerAuthenticatedUserResponseBody(
+                @JsonProperty(FIELD_NAME_AUTHENTICATED) boolean authenticated,
+                @Nullable @JsonProperty(FIELD_NAME_USER) String user,
+                @Nullable @JsonProperty(FIELD_NAME_PRINCIPAL) String principal,
+                @Nullable @JsonProperty(FIELD_NAME_TYPE) String type) {
+            this.authenticated = authenticated;
+            this.user = user;
+            this.principal = principal;
+            this.type = type;
+        }
+
+        static JobManagerAuthenticatedUserResponseBody authenticated(
+                JobManagerAuthenticatedUser user) {
+            return new JobManagerAuthenticatedUserResponseBody(
+                    true, user.getUserName(), user.getPrincipal(), user.getType());
+        }
+
+        static JobManagerAuthenticatedUserResponseBody unauthenticated() {
+            return new JobManagerAuthenticatedUserResponseBody(false, null, null, null);
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/security/JobManagerAuthenticatedUserHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/security/JobManagerAuthenticatedUserHeaders.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.webmonitor.security;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.RuntimeMessageHeaders;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+/** Message headers for exposing the current JobManager web user to the dashboard. */
+public final class JobManagerAuthenticatedUserHeaders
+        implements RuntimeMessageHeaders<
+                EmptyRequestBody,
+                JobManagerAuthenticatedUserHandler.JobManagerAuthenticatedUserResponseBody,
+                EmptyMessageParameters> {
+
+    private static final JobManagerAuthenticatedUserHeaders INSTANCE =
+            new JobManagerAuthenticatedUserHeaders();
+
+    public static final String URL = "/auth/user";
+
+    private JobManagerAuthenticatedUserHeaders() {}
+
+    @Override
+    public Class<EmptyRequestBody> getRequestClass() {
+        return EmptyRequestBody.class;
+    }
+
+    @Override
+    public HttpMethodWrapper getHttpMethod() {
+        return HttpMethodWrapper.GET;
+    }
+
+    @Override
+    public String getTargetRestEndpointURL() {
+        return URL;
+    }
+
+    @Override
+    public Class<JobManagerAuthenticatedUserHandler.JobManagerAuthenticatedUserResponseBody>
+            getResponseClass() {
+        return JobManagerAuthenticatedUserHandler.JobManagerAuthenticatedUserResponseBody.class;
+    }
+
+    @Override
+    public HttpResponseStatus getResponseStatusCode() {
+        return HttpResponseStatus.OK;
+    }
+
+    @Override
+    public EmptyMessageParameters getUnresolvedMessageParameters() {
+        return EmptyMessageParameters.getInstance();
+    }
+
+    @Override
+    public String getDescription() {
+        return "Returns the current authenticated JobManager web user.";
+    }
+
+    public static JobManagerAuthenticatedUserHeaders getInstance() {
+        return INSTANCE;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/security/JobManagerAuthenticationTokenSigner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/security/JobManagerAuthenticationTokenSigner.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.webmonitor.security;
+
+import org.apache.hadoop.security.authentication.client.AuthenticationException;
+import org.apache.hadoop.security.authentication.server.AuthenticationToken;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.Optional;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Signs and verifies Hadoop-compatible JobManager web authentication tokens. */
+final class JobManagerAuthenticationTokenSigner {
+
+    static final String TOKEN_TYPE_KERBEROS = "kerberos";
+
+    private static final String SIGNATURE_SEPARATOR = "&s=";
+    private static final String SIGNING_ALGORITHM = "HmacSHA256";
+
+    private final byte[] secret;
+    private final Duration tokenValidity;
+    private final Clock clock;
+
+    JobManagerAuthenticationTokenSigner(byte[] secret, Duration tokenValidity, Clock clock) {
+        this.secret = checkNotNull(secret, "secret must not be null").clone();
+        checkArgument(this.secret.length > 0, "secret must not be empty");
+        this.tokenValidity = checkNotNull(tokenValidity, "tokenValidity must not be null");
+        this.clock = checkNotNull(clock, "clock must not be null");
+    }
+
+    String signToken(String userName, String principal) {
+        AuthenticationToken token =
+                new AuthenticationToken(userName, principal, TOKEN_TYPE_KERBEROS);
+        token.setExpires(clock.millis() + tokenValidity.toMillis());
+        return sign(token.toString());
+    }
+
+    Optional<AuthenticationToken> verifyToken(String signedToken) {
+        if (signedToken == null || signedToken.isEmpty()) {
+            return Optional.empty();
+        }
+        try {
+            AuthenticationToken token =
+                    AuthenticationToken.parse(verifyAndExtract(stripQuotes(signedToken)));
+            if (!TOKEN_TYPE_KERBEROS.equals(token.getType())) {
+                return Optional.empty();
+            }
+            if (token.getExpires() != -1 && clock.millis() > token.getExpires()) {
+                return Optional.empty();
+            }
+            return Optional.of(token);
+        } catch (AuthenticationException | IllegalArgumentException e) {
+            return Optional.empty();
+        }
+    }
+
+    private String sign(String rawToken) {
+        return rawToken + SIGNATURE_SEPARATOR + computeSignature(rawToken);
+    }
+
+    private String verifyAndExtract(String signedToken) {
+        int index = signedToken.lastIndexOf(SIGNATURE_SEPARATOR);
+        if (index < 0) {
+            throw new IllegalArgumentException("Authentication token is not signed.");
+        }
+
+        String rawToken = signedToken.substring(0, index);
+        String expectedSignature = computeSignature(rawToken);
+        String actualSignature = signedToken.substring(index + SIGNATURE_SEPARATOR.length());
+        if (!MessageDigest.isEqual(
+                expectedSignature.getBytes(StandardCharsets.UTF_8),
+                actualSignature.getBytes(StandardCharsets.UTF_8))) {
+            throw new IllegalArgumentException("Authentication token signature is invalid.");
+        }
+        return rawToken;
+    }
+
+    private String computeSignature(String value) {
+        try {
+            Mac mac = Mac.getInstance(SIGNING_ALGORITHM);
+            mac.init(new SecretKeySpec(secret, SIGNING_ALGORITHM));
+            return Base64.getEncoder()
+                    .encodeToString(mac.doFinal(value.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            throw new IllegalStateException(
+                    "Could not sign JobManager web authentication token.", e);
+        }
+    }
+
+    private static String stripQuotes(String value) {
+        if (value != null
+                && value.length() >= 2
+                && value.startsWith("\"")
+                && value.endsWith("\"")) {
+            return value.substring(1, value.length() - 1);
+        }
+        return value;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/security/JobManagerSpnegoAuthenticationResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/security/JobManagerSpnegoAuthenticationResult.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.webmonitor.security;
+
+import org.apache.hadoop.security.authentication.server.AuthenticationToken;
+
+import javax.annotation.Nullable;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Result of one JobManager web SPNEGO authentication step. */
+final class JobManagerSpnegoAuthenticationResult {
+
+    private final AuthenticationToken authenticationToken;
+    private final String authenticateHeader;
+
+    private JobManagerSpnegoAuthenticationResult(
+            @Nullable AuthenticationToken authenticationToken,
+            @Nullable String authenticateHeader) {
+        this.authenticationToken = authenticationToken;
+        this.authenticateHeader = authenticateHeader;
+    }
+
+    static JobManagerSpnegoAuthenticationResult challenge(String authenticateHeader) {
+        return new JobManagerSpnegoAuthenticationResult(null, checkNotNull(authenticateHeader));
+    }
+
+    static JobManagerSpnegoAuthenticationResult authenticated(
+            AuthenticationToken authenticationToken, @Nullable String authenticateHeader) {
+        return new JobManagerSpnegoAuthenticationResult(
+                checkNotNull(authenticationToken), authenticateHeader);
+    }
+
+    boolean isAuthenticated() {
+        return authenticationToken != null;
+    }
+
+    AuthenticationToken authenticationToken() {
+        return checkNotNull(authenticationToken);
+    }
+
+    @Nullable
+    String authenticateHeader() {
+        return authenticateHeader;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/security/JobManagerSpnegoAuthenticator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/security/JobManagerSpnegoAuthenticator.java
@@ -1,0 +1,283 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.webmonitor.security;
+
+import org.apache.flink.util.ConfigurationException;
+
+import org.apache.hadoop.security.authentication.client.AuthenticationException;
+import org.apache.hadoop.security.authentication.server.AuthenticationToken;
+import org.apache.hadoop.security.authentication.util.KerberosName;
+import org.apache.hadoop.security.authentication.util.KerberosUtil;
+import org.ietf.jgss.GSSContext;
+import org.ietf.jgss.GSSCredential;
+import org.ietf.jgss.GSSException;
+import org.ietf.jgss.GSSManager;
+import org.ietf.jgss.Oid;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import javax.security.auth.Subject;
+import javax.security.auth.kerberos.KerberosKey;
+import javax.security.auth.kerberos.KerberosPrincipal;
+import javax.security.auth.kerberos.KeyTab;
+
+import java.io.File;
+import java.io.IOException;
+import java.security.Principal;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.Base64;
+import java.util.regex.Pattern;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Kerberos/SPNEGO acceptor for the JobManager web endpoint. */
+final class JobManagerSpnegoAuthenticator implements SpnegoAuthenticator {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JobManagerSpnegoAuthenticator.class);
+
+    static final String AUTHENTICATION_SCHEME_NEGOTIATE = "Negotiate";
+    static final String AUTHENTICATE_HEADER_NEGOTIATE = "Negotiate";
+
+    private static final Pattern HTTP_PRINCIPAL_PATTERN = Pattern.compile("HTTP/.*");
+
+    private final Subject serverSubject;
+    private final GSSManager gssManager;
+
+    private JobManagerSpnegoAuthenticator(Subject serverSubject, GSSManager gssManager) {
+        this.serverSubject = checkNotNull(serverSubject);
+        this.gssManager = checkNotNull(gssManager);
+    }
+
+    static JobManagerSpnegoAuthenticator create(JobManagerWebAuthenticationConfig config)
+            throws ConfigurationException {
+        File keytabFile = config.getKerberosKeytab().toFile();
+        if (!keytabFile.isFile()) {
+            throw new ConfigurationException(
+                    "JobManager web authentication Kerberos keytab does not exist or is not a file: "
+                            + config.getKerberosKeytab());
+        }
+
+        Subject serverSubject = new Subject();
+        KeyTab keytab = KeyTab.getInstance(keytabFile);
+        serverSubject.getPrivateCredentials().add(keytab);
+
+        if ("*".equals(config.getKerberosPrincipal())) {
+            addWildcardHttpPrincipals(serverSubject, config.getKerberosKeytab().toString());
+        } else {
+            addPrincipal(
+                    serverSubject,
+                    keytab,
+                    config.getKerberosPrincipal(),
+                    config.getKerberosKeytab().toString());
+        }
+
+        configureKerberosNameRules(config);
+
+        GSSManager gssManager;
+        try {
+            gssManager =
+                    Subject.doAs(
+                            serverSubject,
+                            (PrivilegedExceptionAction<GSSManager>) GSSManager::getInstance);
+        } catch (PrivilegedActionException e) {
+            throw new ConfigurationException(
+                    "Could not initialize JobManager web SPNEGO acceptor.", e.getException());
+        }
+
+        return new JobManagerSpnegoAuthenticator(serverSubject, gssManager);
+    }
+
+    @Override
+    public JobManagerSpnegoAuthenticationResult authenticate(String authorizationHeader)
+            throws AuthenticationException {
+        if (!hasNegotiateScheme(authorizationHeader)) {
+            return JobManagerSpnegoAuthenticationResult.challenge(AUTHENTICATE_HEADER_NEGOTIATE);
+        }
+
+        String encodedClientToken =
+                authorizationHeader.substring(AUTHENTICATION_SCHEME_NEGOTIATE.length()).trim();
+        if (encodedClientToken.isEmpty()) {
+            throw new AuthenticationException("Missing SPNEGO token.");
+        }
+
+        byte[] clientToken;
+        try {
+            clientToken = Base64.getDecoder().decode(encodedClientToken);
+        } catch (IllegalArgumentException e) {
+            throw new AuthenticationException("Invalid SPNEGO token encoding.", e);
+        }
+
+        try {
+            String serverPrincipal = KerberosUtil.getTokenServerName(clientToken);
+            if (!serverPrincipal.startsWith("HTTP/")) {
+                throw new AuthenticationException(
+                        "Invalid SPNEGO server principal in client token.");
+            }
+            return Subject.doAs(
+                    serverSubject,
+                    (PrivilegedExceptionAction<JobManagerSpnegoAuthenticationResult>)
+                            () -> runWithPrincipal(serverPrincipal, clientToken));
+        } catch (PrivilegedActionException e) {
+            Throwable cause = e.getException();
+            if (cause instanceof AuthenticationException) {
+                throw (AuthenticationException) cause;
+            }
+            throw new AuthenticationException(cause);
+        } catch (AuthenticationException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new AuthenticationException(e);
+        }
+    }
+
+    private JobManagerSpnegoAuthenticationResult runWithPrincipal(
+            String serverPrincipal, byte[] clientToken) throws GSSException, IOException {
+        GSSContext gssContext = null;
+        GSSCredential gssCredential = null;
+        try {
+            LOG.trace(
+                    "Starting JobManager web SPNEGO step for server principal {}.",
+                    serverPrincipal);
+            gssCredential =
+                    gssManager.createCredential(
+                            gssManager.createName(
+                                    serverPrincipal, KerberosUtil.NT_GSS_KRB5_PRINCIPAL_OID),
+                            GSSCredential.INDEFINITE_LIFETIME,
+                            new Oid[] {
+                                KerberosUtil.GSS_SPNEGO_MECH_OID, KerberosUtil.GSS_KRB5_MECH_OID
+                            },
+                            GSSCredential.ACCEPT_ONLY);
+            gssContext = gssManager.createContext(gssCredential);
+            byte[] serverToken = gssContext.acceptSecContext(clientToken, 0, clientToken.length);
+            String authenticateHeader = createAuthenticateHeader(serverToken);
+
+            if (!gssContext.isEstablished()) {
+                LOG.trace("JobManager web SPNEGO step is not complete yet.");
+                return JobManagerSpnegoAuthenticationResult.challenge(
+                        authenticateHeader == null
+                                ? AUTHENTICATE_HEADER_NEGOTIATE
+                                : authenticateHeader);
+            }
+
+            String clientPrincipal = gssContext.getSrcName().toString();
+            String userName = new KerberosName(clientPrincipal).getShortName();
+            AuthenticationToken token =
+                    new AuthenticationToken(
+                            userName,
+                            clientPrincipal,
+                            JobManagerAuthenticationTokenSigner.TOKEN_TYPE_KERBEROS);
+            LOG.trace("JobManager web SPNEGO completed for client principal {}.", clientPrincipal);
+            return JobManagerSpnegoAuthenticationResult.authenticated(token, authenticateHeader);
+        } finally {
+            if (gssContext != null) {
+                gssContext.dispose();
+            }
+            if (gssCredential != null) {
+                gssCredential.dispose();
+            }
+        }
+    }
+
+    @Nullable
+    private static String createAuthenticateHeader(byte[] serverToken) {
+        if (serverToken == null || serverToken.length == 0) {
+            return null;
+        }
+        return AUTHENTICATE_HEADER_NEGOTIATE
+                + " "
+                + Base64.getEncoder().encodeToString(serverToken);
+    }
+
+    private static boolean hasNegotiateScheme(String authorizationHeader) {
+        return authorizationHeader != null
+                && authorizationHeader.length() >= AUTHENTICATION_SCHEME_NEGOTIATE.length()
+                && authorizationHeader.regionMatches(
+                        true,
+                        0,
+                        AUTHENTICATION_SCHEME_NEGOTIATE,
+                        0,
+                        AUTHENTICATION_SCHEME_NEGOTIATE.length())
+                && (authorizationHeader.length() == AUTHENTICATION_SCHEME_NEGOTIATE.length()
+                        || Character.isWhitespace(
+                                authorizationHeader.charAt(
+                                        AUTHENTICATION_SCHEME_NEGOTIATE.length())));
+    }
+
+    private static void addWildcardHttpPrincipals(Subject serverSubject, String keytab)
+            throws ConfigurationException {
+        String[] principals;
+        try {
+            principals = KerberosUtil.getPrincipalNames(keytab, HTTP_PRINCIPAL_PATTERN);
+        } catch (IOException e) {
+            throw new ConfigurationException(
+                    "Could not read JobManager web authentication Kerberos keytab.", e);
+        }
+        if (principals.length == 0) {
+            throw new ConfigurationException(
+                    "JobManager web authentication Kerberos keytab does not contain any HTTP principals.");
+        }
+        for (String principal : principals) {
+            addPrincipal(serverSubject, null, principal, keytab);
+        }
+    }
+
+    private static void addPrincipal(
+            Subject serverSubject, KeyTab keytab, String principal, String keytabPath)
+            throws ConfigurationException {
+        try {
+            Principal kerberosPrincipal = new KerberosPrincipal(principal);
+            if (keytab != null) {
+                KerberosKey[] keys = keytab.getKeys((KerberosPrincipal) kerberosPrincipal);
+                if (keys.length == 0) {
+                    throw new ConfigurationException(
+                            String.format(
+                                    "JobManager web authentication Kerberos keytab '%s' does not contain principal '%s'.",
+                                    keytabPath, principal));
+                }
+                for (KerberosKey key : keys) {
+                    key.destroy();
+                }
+            }
+            serverSubject.getPrincipals().add(kerberosPrincipal);
+            LOG.info(
+                    "Using JobManager web SPNEGO keytab {} for principal {}.",
+                    keytabPath,
+                    principal);
+        } catch (IllegalArgumentException e) {
+            throw new ConfigurationException(
+                    "Invalid JobManager web authentication Kerberos principal: " + principal, e);
+        } catch (javax.security.auth.DestroyFailedException e) {
+            throw new ConfigurationException(
+                    "Could not validate JobManager web authentication Kerberos keytab.", e);
+        }
+    }
+
+    private static void configureKerberosNameRules(JobManagerWebAuthenticationConfig config)
+            throws ConfigurationException {
+        try {
+            KerberosName.setRules(config.getKerberosNameRules());
+            KerberosName.setRuleMechanism(KerberosName.DEFAULT_MECHANISM);
+        } catch (IllegalArgumentException e) {
+            throw new ConfigurationException(
+                    "Invalid JobManager web SPNEGO Kerberos name rules.", e);
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/security/JobManagerWebAuthenticationConfig.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/security/JobManagerWebAuthenticationConfig.java
@@ -1,0 +1,295 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.webmonitor.security;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.configuration.SecurityOptions;
+import org.apache.flink.configuration.WebOptions.WebAuthenticationType;
+import org.apache.flink.util.ConfigurationException;
+import org.apache.flink.util.StringUtils;
+
+import org.apache.hadoop.security.authentication.util.KerberosUtil;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.util.Locale;
+import java.util.Optional;
+
+import static org.apache.flink.configuration.WebOptions.AUTHENTICATION_COOKIE_PATH;
+import static org.apache.flink.configuration.WebOptions.AUTHENTICATION_KERBEROS_KEYTAB;
+import static org.apache.flink.configuration.WebOptions.AUTHENTICATION_KERBEROS_NAME_RULES;
+import static org.apache.flink.configuration.WebOptions.AUTHENTICATION_KERBEROS_PRINCIPAL;
+import static org.apache.flink.configuration.WebOptions.AUTHENTICATION_SIGNATURE_SECRET;
+import static org.apache.flink.configuration.WebOptions.AUTHENTICATION_SIGNATURE_SECRET_FILE;
+import static org.apache.flink.configuration.WebOptions.AUTHENTICATION_TOKEN_VALIDITY;
+import static org.apache.flink.configuration.WebOptions.AUTHENTICATION_TYPE;
+
+/** Parsed and validated JobManager web authentication configuration. */
+final class JobManagerWebAuthenticationConfig {
+
+    private static final int RANDOM_SECRET_BYTES = 32;
+
+    private final String kerberosPrincipal;
+    private final Path kerberosKeytab;
+    private final String kerberosNameRules;
+    private final Duration tokenValidity;
+    private final String cookiePath;
+    private final byte[] signatureSecret;
+    private final boolean secureCookie;
+
+    private JobManagerWebAuthenticationConfig(
+            String kerberosPrincipal,
+            Path kerberosKeytab,
+            String kerberosNameRules,
+            Duration tokenValidity,
+            String cookiePath,
+            byte[] signatureSecret,
+            boolean secureCookie) {
+        this.kerberosPrincipal = kerberosPrincipal;
+        this.kerberosKeytab = kerberosKeytab;
+        this.kerberosNameRules = kerberosNameRules;
+        this.tokenValidity = tokenValidity;
+        this.cookiePath = cookiePath;
+        this.signatureSecret = signatureSecret.clone();
+        this.secureCookie = secureCookie;
+    }
+
+    static Optional<JobManagerWebAuthenticationConfig> fromConfiguration(
+            Configuration configuration) throws ConfigurationException {
+        WebAuthenticationType type = getAuthenticationType(configuration);
+        if (type == WebAuthenticationType.NONE) {
+            return Optional.empty();
+        }
+        if (type != WebAuthenticationType.KERBEROS) {
+            throw new ConfigurationException(
+                    "Unsupported " + AUTHENTICATION_TYPE.key() + " value: " + type);
+        }
+
+        return Optional.of(
+                new JobManagerWebAuthenticationConfig(
+                        resolvePrincipal(
+                                required(configuration, AUTHENTICATION_KERBEROS_PRINCIPAL),
+                                configuration),
+                        resolveKeytab(required(configuration, AUTHENTICATION_KERBEROS_KEYTAB)),
+                        configuration.get(AUTHENTICATION_KERBEROS_NAME_RULES),
+                        validateTokenValidity(configuration.get(AUTHENTICATION_TOKEN_VALIDITY)),
+                        validateCookiePath(configuration.get(AUTHENTICATION_COOKIE_PATH)),
+                        resolveSignatureSecret(configuration),
+                        SecurityOptions.isRestSSLEnabled(configuration)));
+    }
+
+    String getKerberosPrincipal() {
+        return kerberosPrincipal;
+    }
+
+    Path getKerberosKeytab() {
+        return kerberosKeytab;
+    }
+
+    String getKerberosNameRules() {
+        return kerberosNameRules;
+    }
+
+    Duration getTokenValidity() {
+        return tokenValidity;
+    }
+
+    String getCookiePath() {
+        return cookiePath;
+    }
+
+    byte[] getSignatureSecret() {
+        return signatureSecret.clone();
+    }
+
+    boolean isSecureCookie() {
+        return secureCookie;
+    }
+
+    private static WebAuthenticationType getAuthenticationType(Configuration configuration)
+            throws ConfigurationException {
+        try {
+            return configuration.get(AUTHENTICATION_TYPE);
+        } catch (IllegalArgumentException e) {
+            throw new ConfigurationException(
+                    "Unsupported " + AUTHENTICATION_TYPE.key() + " value.", e);
+        }
+    }
+
+    private static String resolvePrincipal(String principal, Configuration configuration)
+            throws ConfigurationException {
+        if ("*".equals(principal)) {
+            return principal;
+        }
+        String resolvedPrincipal = principal.replace("_HOST", resolveHostName(configuration));
+        if (!resolvedPrincipal.startsWith("HTTP/")) {
+            throw new ConfigurationException(
+                    AUTHENTICATION_KERBEROS_PRINCIPAL.key() + " must start with HTTP/ or be '*'.");
+        }
+        return resolvedPrincipal;
+    }
+
+    private static String resolveHostName(Configuration configuration)
+            throws ConfigurationException {
+        Optional<String> configuredHost =
+                firstUsableHost(
+                        configuration.getOptional(RestOptions.ADDRESS),
+                        configuration.getOptional(RestOptions.BIND_ADDRESS));
+        if (configuredHost.isPresent()) {
+            try {
+                return InetAddress.getByName(configuredHost.get())
+                        .getCanonicalHostName()
+                        .toLowerCase(Locale.ROOT);
+            } catch (UnknownHostException e) {
+                throw new ConfigurationException(
+                        "Could not resolve _HOST in JobManager web Kerberos principal.", e);
+            }
+        }
+        try {
+            return KerberosUtil.getLocalHostName().toLowerCase(Locale.ROOT);
+        } catch (UnknownHostException e) {
+            throw new ConfigurationException(
+                    "Could not resolve local hostname for JobManager web Kerberos principal.", e);
+        }
+    }
+
+    @SafeVarargs
+    private static Optional<String> firstUsableHost(Optional<String>... hosts) {
+        for (Optional<String> host : hosts) {
+            Optional<String> usableHost =
+                    host.map(String::trim)
+                            .filter(value -> !value.isEmpty())
+                            .filter(value -> !isWildcardAddress(value));
+            if (usableHost.isPresent()) {
+                return usableHost;
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static boolean isWildcardAddress(String value) {
+        return "0.0.0.0".equals(value) || "::".equals(value) || "[::]".equals(value);
+    }
+
+    private static Path resolveKeytab(String keytab) throws ConfigurationException {
+        Path keytabPath = Path.of(keytab);
+        if (!Files.isRegularFile(keytabPath) || !Files.isReadable(keytabPath)) {
+            throw new ConfigurationException(
+                    AUTHENTICATION_KERBEROS_KEYTAB.key()
+                            + " does not point to a readable regular file: "
+                            + keytabPath);
+        }
+        return keytabPath;
+    }
+
+    private static Duration validateTokenValidity(Duration tokenValidity)
+            throws ConfigurationException {
+        if (tokenValidity == null || tokenValidity.isZero() || tokenValidity.isNegative()) {
+            throw new ConfigurationException(
+                    AUTHENTICATION_TOKEN_VALIDITY.key() + " must be greater than 0.");
+        }
+        return tokenValidity;
+    }
+
+    private static String validateCookiePath(String cookiePath) throws ConfigurationException {
+        if (StringUtils.isNullOrWhitespaceOnly(cookiePath) || !cookiePath.startsWith("/")) {
+            throw new ConfigurationException(
+                    AUTHENTICATION_COOKIE_PATH.key() + " must be a non-empty absolute path.");
+        }
+        return cookiePath;
+    }
+
+    private static byte[] resolveSignatureSecret(Configuration configuration)
+            throws ConfigurationException {
+        Optional<String> configuredSecret =
+                optionalNonBlank(configuration, AUTHENTICATION_SIGNATURE_SECRET);
+        Optional<String> configuredSecretFile =
+                optionalNonBlank(configuration, AUTHENTICATION_SIGNATURE_SECRET_FILE);
+
+        if (configuredSecret.isPresent() && configuredSecretFile.isPresent()) {
+            throw new ConfigurationException(
+                    "Only one of "
+                            + AUTHENTICATION_SIGNATURE_SECRET.key()
+                            + " and "
+                            + AUTHENTICATION_SIGNATURE_SECRET_FILE.key()
+                            + " may be configured.");
+        }
+
+        if (configuredSecret.isPresent()) {
+            return configuredSecret.get().getBytes(StandardCharsets.UTF_8);
+        }
+        if (configuredSecretFile.isPresent()) {
+            return readSecretFile(configuredSecretFile.get());
+        }
+        return createRandomSecret();
+    }
+
+    private static byte[] readSecretFile(String secretFile) throws ConfigurationException {
+        try {
+            String secret = Files.readString(Path.of(secretFile), StandardCharsets.UTF_8).trim();
+            if (secret.isEmpty()) {
+                throw new ConfigurationException(
+                        AUTHENTICATION_SIGNATURE_SECRET_FILE.key() + " must not be empty.");
+            }
+            return secret.getBytes(StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new ConfigurationException(
+                    "Could not read "
+                            + AUTHENTICATION_SIGNATURE_SECRET_FILE.key()
+                            + ": "
+                            + secretFile,
+                    e);
+        }
+    }
+
+    private static byte[] createRandomSecret() {
+        byte[] secret = new byte[RANDOM_SECRET_BYTES];
+        new SecureRandom().nextBytes(secret);
+        return secret;
+    }
+
+    private static String required(
+            Configuration configuration, org.apache.flink.configuration.ConfigOption<String> option)
+            throws ConfigurationException {
+        return optionalNonBlank(configuration, option)
+                .orElseThrow(
+                        () ->
+                                new ConfigurationException(
+                                        option.key()
+                                                + " must be configured when "
+                                                + AUTHENTICATION_TYPE.key()
+                                                + " is KERBEROS."));
+    }
+
+    private static Optional<String> optionalNonBlank(
+            Configuration configuration,
+            org.apache.flink.configuration.ConfigOption<String> option) {
+        return configuration
+                .getOptional(option)
+                .map(String::trim)
+                .filter(value -> !value.isEmpty());
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/security/JobManagerWebAuthenticationHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/security/JobManagerWebAuthenticationHandler.java
@@ -1,0 +1,309 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.webmonitor.security;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.ConfigurationException;
+
+import org.apache.flink.shaded.netty4.io.netty.buffer.Unpooled;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelDuplexHandler;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelFutureListener;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandler;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelPromise;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.DefaultFullHttpResponse;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.FullHttpRequest;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.FullHttpResponse;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpHeaderNames;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpHeaderValues;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpHeaders;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponse;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpUtil;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpVersion;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.cookie.Cookie;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.cookie.ServerCookieDecoder;
+import org.apache.flink.shaded.netty4.io.netty.util.AttributeKey;
+import org.apache.flink.shaded.netty4.io.netty.util.ReferenceCountUtil;
+
+import org.apache.hadoop.security.authentication.client.AuthenticatedURL;
+import org.apache.hadoop.security.authentication.client.AuthenticationException;
+import org.apache.hadoop.security.authentication.server.AuthenticationToken;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.time.Clock;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Netty handler that enforces JobManager web SPNEGO authentication. */
+public final class JobManagerWebAuthenticationHandler extends ChannelDuplexHandler {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(JobManagerWebAuthenticationHandler.class);
+
+    private static final AttributeKey<ResponseAuthentication> RESPONSE_AUTHENTICATION_ATTRIBUTE =
+            AttributeKey.valueOf("jobmanager-web-spnego-response-authentication");
+    private static final AttributeKey<JobManagerAuthenticatedUser> AUTHENTICATED_USER =
+            AttributeKey.valueOf("jobmanager-web-authenticated-user");
+
+    private final SpnegoAuthenticator authenticator;
+    private final JobManagerAuthenticationTokenSigner tokenSigner;
+    private final String cookiePath;
+    private final boolean secureCookie;
+    private final Map<String, String> responseHeaders;
+
+    JobManagerWebAuthenticationHandler(
+            SpnegoAuthenticator authenticator,
+            JobManagerAuthenticationTokenSigner tokenSigner,
+            String cookiePath,
+            boolean secureCookie,
+            Map<String, String> responseHeaders) {
+        this.authenticator = checkNotNull(authenticator);
+        this.tokenSigner = checkNotNull(tokenSigner);
+        this.cookiePath = checkNotNull(cookiePath);
+        this.secureCookie = secureCookie;
+        this.responseHeaders = checkNotNull(responseHeaders);
+    }
+
+    public static Optional<Factory> createFactory(
+            Configuration configuration, Map<String, String> responseHeaders)
+            throws ConfigurationException {
+        Optional<JobManagerWebAuthenticationConfig> config =
+                JobManagerWebAuthenticationConfig.fromConfiguration(configuration);
+        if (!config.isPresent()) {
+            return Optional.empty();
+        }
+
+        JobManagerWebAuthenticationConfig authenticationConfig = config.get();
+        SpnegoAuthenticator authenticator =
+                JobManagerSpnegoAuthenticator.create(authenticationConfig);
+        JobManagerAuthenticationTokenSigner signer =
+                new JobManagerAuthenticationTokenSigner(
+                        authenticationConfig.getSignatureSecret(),
+                        authenticationConfig.getTokenValidity(),
+                        Clock.systemUTC());
+
+        return Optional.of(
+                () ->
+                        new JobManagerWebAuthenticationHandler(
+                                authenticator,
+                                signer,
+                                authenticationConfig.getCookiePath(),
+                                authenticationConfig.isSecureCookie(),
+                                responseHeaders));
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        if (!(msg instanceof FullHttpRequest)) {
+            ctx.fireChannelRead(msg);
+            return;
+        }
+
+        FullHttpRequest request = (FullHttpRequest) msg;
+        Optional<AuthenticationToken> cookieToken = getAuthenticationTokenFromCookie(request);
+        if (cookieToken.isPresent()) {
+            setAuthenticatedUser(ctx, cookieToken.get());
+            try {
+                ctx.fireChannelRead(msg);
+            } finally {
+                clearAuthenticatedUser(ctx);
+            }
+            return;
+        }
+
+        try {
+            JobManagerSpnegoAuthenticationResult result =
+                    authenticator.authenticate(
+                            request.headers().get(HttpHeaderNames.AUTHORIZATION));
+            if (!result.isAuthenticated()) {
+                sendResponse(
+                        ctx,
+                        request,
+                        HttpResponseStatus.UNAUTHORIZED,
+                        result.authenticateHeader(),
+                        true);
+                return;
+            }
+
+            AuthenticationToken authenticationToken = result.authenticationToken();
+            String signedToken =
+                    tokenSigner.signToken(
+                            authenticationToken.getUserName(), authenticationToken.getName());
+            ctx.channel()
+                    .attr(RESPONSE_AUTHENTICATION_ATTRIBUTE)
+                    .set(new ResponseAuthentication(signedToken, result.authenticateHeader()));
+            setAuthenticatedUser(ctx, authenticationToken);
+            try {
+                ctx.fireChannelRead(msg);
+            } finally {
+                clearAuthenticatedUser(ctx);
+            }
+        } catch (AuthenticationException e) {
+            LOG.debug("JobManager web SPNEGO authentication failed.", e);
+            clearAuthenticatedUser(ctx);
+            sendResponse(ctx, request, HttpResponseStatus.FORBIDDEN, null, true);
+        }
+    }
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise)
+            throws Exception {
+        if (msg instanceof HttpResponse) {
+            ResponseAuthentication responseAuthentication =
+                    ctx.channel().attr(RESPONSE_AUTHENTICATION_ATTRIBUTE).getAndSet(null);
+            if (responseAuthentication != null) {
+                HttpHeaders headers = ((HttpResponse) msg).headers();
+                headers.add(HttpHeaderNames.SET_COOKIE, createAuthCookie(responseAuthentication));
+                if (responseAuthentication.authenticateHeader() != null) {
+                    headers.set(
+                            HttpHeaderNames.WWW_AUTHENTICATE,
+                            responseAuthentication.authenticateHeader());
+                }
+            }
+        }
+        ctx.write(msg, promise);
+    }
+
+    private Optional<AuthenticationToken> getAuthenticationTokenFromCookie(
+            FullHttpRequest request) {
+        for (String cookieHeader : request.headers().getAll(HttpHeaderNames.COOKIE)) {
+            try {
+                Set<Cookie> cookies = ServerCookieDecoder.STRICT.decode(cookieHeader);
+                for (Cookie cookie : cookies) {
+                    if (AuthenticatedURL.AUTH_COOKIE.equals(cookie.name())) {
+                        Optional<AuthenticationToken> token =
+                                tokenSigner.verifyToken(cookie.value());
+                        if (token.isPresent()) {
+                            return token;
+                        }
+                    }
+                }
+            } catch (IllegalArgumentException e) {
+                LOG.debug("Ignoring malformed JobManager web Cookie header.", e);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static void setAuthenticatedUser(
+            ChannelHandlerContext ctx, AuthenticationToken authenticationToken) {
+        ctx.channel()
+                .attr(AUTHENTICATED_USER)
+                .set(
+                        new JobManagerAuthenticatedUser(
+                                authenticationToken.getUserName(),
+                                authenticationToken.getName(),
+                                authenticationToken.getType()));
+    }
+
+    private static void clearAuthenticatedUser(ChannelHandlerContext ctx) {
+        ctx.channel().attr(AUTHENTICATED_USER).set(null);
+    }
+
+    public static Optional<JobManagerAuthenticatedUser> getAuthenticatedUser(
+            ChannelHandlerContext ctx) {
+        return Optional.ofNullable(ctx.channel().attr(AUTHENTICATED_USER).get());
+    }
+
+    private void sendResponse(
+            ChannelHandlerContext ctx,
+            FullHttpRequest request,
+            HttpResponseStatus status,
+            @Nullable String authenticateHeader,
+            boolean expireCookie) {
+        clearAuthenticatedUser(ctx);
+        FullHttpResponse response =
+                new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, status, Unpooled.EMPTY_BUFFER);
+        responseHeaders.forEach((name, value) -> response.headers().set(name, value));
+        response.headers().set(HttpHeaderNames.CONTENT_LENGTH, 0);
+        if (authenticateHeader != null) {
+            response.headers().set(HttpHeaderNames.WWW_AUTHENTICATE, authenticateHeader);
+        }
+        if (expireCookie) {
+            response.headers().add(HttpHeaderNames.SET_COOKIE, createExpiredAuthCookie());
+        }
+
+        boolean keepAlive = HttpUtil.isKeepAlive(request);
+        ReferenceCountUtil.release(request);
+        if (keepAlive) {
+            response.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
+            ctx.writeAndFlush(response);
+        } else {
+            ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
+        }
+    }
+
+    private String createAuthCookie(ResponseAuthentication responseAuthentication) {
+        StringBuilder cookie =
+                new StringBuilder(AuthenticatedURL.AUTH_COOKIE)
+                        .append("=\"")
+                        .append(responseAuthentication.signedToken())
+                        .append("\"; Path=")
+                        .append(cookiePath);
+        if (secureCookie) {
+            cookie.append("; Secure");
+        }
+        cookie.append("; HttpOnly");
+        return cookie.toString();
+    }
+
+    private String createExpiredAuthCookie() {
+        StringBuilder cookie =
+                new StringBuilder(AuthenticatedURL.AUTH_COOKIE)
+                        .append("=; Path=")
+                        .append(cookiePath)
+                        .append("; Max-Age=0");
+        if (secureCookie) {
+            cookie.append("; Secure");
+        }
+        cookie.append("; HttpOnly");
+        return cookie.toString();
+    }
+
+    /** Factory for per-channel JobManager web authentication handlers. */
+    public interface Factory {
+        ChannelHandler createHandler();
+    }
+
+    private static final class ResponseAuthentication {
+        private final String signedToken;
+        @Nullable private final String authenticateHeader;
+
+        private ResponseAuthentication(String signedToken, @Nullable String authenticateHeader) {
+            this.signedToken = signedToken;
+            this.authenticateHeader = authenticateHeader;
+        }
+
+        private String signedToken() {
+            return signedToken;
+        }
+
+        @Nullable
+        private String authenticateHeader() {
+            return authenticateHeader;
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/security/SpnegoAuthenticator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/security/SpnegoAuthenticator.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.webmonitor.security;
+
+import org.apache.hadoop.security.authentication.client.AuthenticationException;
+
+/** Authentication step contract used by the JobManager web SPNEGO handler. */
+interface SpnegoAuthenticator {
+
+    JobManagerSpnegoAuthenticationResult authenticate(String authorizationHeader)
+            throws AuthenticationException;
+}

--- a/flink-runtime/src/main/resources/META-INF/NOTICE
+++ b/flink-runtime/src/main/resources/META-INF/NOTICE
@@ -7,3 +7,15 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - io.airlift:aircompressor:0.27
+- org.apache.hadoop:hadoop-auth
+- commons-codec:commons-codec
+- org.apache.httpcomponents:httpclient
+- org.apache.httpcomponents:httpcore
+- org.apache.hadoop.thirdparty:hadoop-shaded-guava
+- org.apache.kerby:kerb-core
+- org.apache.kerby:kerby-pkix
+- org.apache.kerby:kerby-asn1
+- org.apache.kerby:kerby-util
+- org.apache.kerby:kerb-util
+- org.apache.kerby:kerby-config
+- org.apache.kerby:kerb-crypto

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/util/TestRestServerEndpoint.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/util/TestRestServerEndpoint.java
@@ -25,12 +25,16 @@ import org.apache.flink.runtime.rest.handler.AbstractRestHandler;
 import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
 import org.apache.flink.util.ConfigurationException;
 
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandler;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandler;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 /** Utility {@link RestServerEndpoint} for setting up a rest server with a given set of handlers. */
 public class TestRestServerEndpoint extends RestServerEndpoint {
@@ -46,6 +50,8 @@ public class TestRestServerEndpoint extends RestServerEndpoint {
 
         private final Configuration configuration;
         private final List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> handlers =
+                new ArrayList<>();
+        private final List<Supplier<ChannelHandler>> endpointSpecificChannelHandlerFactories =
                 new ArrayList<>();
 
         private Builder(Configuration configuration) {
@@ -63,8 +69,20 @@ public class TestRestServerEndpoint extends RestServerEndpoint {
             return this;
         }
 
+        public Builder withEndpointSpecificChannelHandler(ChannelHandler channelHandler) {
+            this.endpointSpecificChannelHandlerFactories.add(() -> channelHandler);
+            return this;
+        }
+
+        public Builder withEndpointSpecificChannelHandlerFactory(
+                Supplier<ChannelHandler> channelHandlerFactory) {
+            this.endpointSpecificChannelHandlerFactories.add(channelHandlerFactory);
+            return this;
+        }
+
         public TestRestServerEndpoint build() throws IOException, ConfigurationException {
-            return new TestRestServerEndpoint(configuration, handlers);
+            return new TestRestServerEndpoint(
+                    configuration, handlers, endpointSpecificChannelHandlerFactories);
         }
 
         public TestRestServerEndpoint buildAndStart() throws Exception {
@@ -76,19 +94,29 @@ public class TestRestServerEndpoint extends RestServerEndpoint {
     }
 
     private final List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> handlers;
+    private final List<Supplier<ChannelHandler>> endpointSpecificChannelHandlerFactories;
 
     private TestRestServerEndpoint(
             final Configuration configuration,
-            final List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> handlers)
+            final List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> handlers,
+            final List<Supplier<ChannelHandler>> endpointSpecificChannelHandlerFactories)
             throws IOException, ConfigurationException {
         super(configuration);
         this.handlers = handlers;
+        this.endpointSpecificChannelHandlerFactories = endpointSpecificChannelHandlerFactories;
     }
 
     @Override
     protected List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> initializeHandlers(
             final CompletableFuture<String> ignore) {
         return this.handlers;
+    }
+
+    @Override
+    protected Collection<ChannelHandler> createEndpointSpecificChannelHandlers() {
+        return endpointSpecificChannelHandlerFactories.stream()
+                .map(Supplier::get)
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpointTest.java
@@ -27,16 +27,24 @@ import org.apache.flink.runtime.leaderelection.StandaloneLeaderElection;
 import org.apache.flink.runtime.rest.handler.RestHandlerConfiguration;
 import org.apache.flink.runtime.rest.handler.legacy.metrics.VoidMetricFetcher;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
+import org.apache.flink.runtime.webmonitor.security.JobManagerAuthenticatedUserHeaders;
+import org.apache.flink.util.ConfigurationException;
 import org.apache.flink.util.ExecutorUtils;
 
 import org.junit.jupiter.api.Test;
 
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the {@link WebMonitorEndpoint}. */
 class WebMonitorEndpointTest {
@@ -45,6 +53,7 @@ class WebMonitorEndpointTest {
     void cleansUpExpiredExecutionGraphs() throws Exception {
         final Configuration configuration = new Configuration();
         configuration.set(RestOptions.ADDRESS, "localhost");
+        configuration.set(RestOptions.BIND_PORT, "0");
         configuration.set(WebOptions.REFRESH_INTERVAL, Duration.ofMillis(5L));
         final ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
         final long timeout = 10000L;
@@ -71,6 +80,85 @@ class WebMonitorEndpointTest {
 
             // check that the cleanup will be triggered
             cleanupLatch.await(timeout, TimeUnit.MILLISECONDS);
+        } finally {
+            ExecutorUtils.gracefulShutdown(timeout, TimeUnit.MILLISECONDS, executor);
+        }
+    }
+
+    @Test
+    void exposesAuthenticatedUserEndpointWhenWebAuthenticationIsDisabled() throws Exception {
+        final Configuration configuration = new Configuration();
+        configuration.set(RestOptions.ADDRESS, "localhost");
+        configuration.set(RestOptions.BIND_PORT, "0");
+        final ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
+        final long timeout = 10000L;
+
+        try (final WebMonitorEndpoint<RestfulGateway> webMonitorEndpoint =
+                new WebMonitorEndpoint<>(
+                        CompletableFuture::new,
+                        configuration,
+                        RestHandlerConfiguration.fromConfiguration(configuration),
+                        CompletableFuture::new,
+                        NoOpTransientBlobService.INSTANCE,
+                        executor,
+                        VoidMetricFetcher.INSTANCE,
+                        new StandaloneLeaderElection(UUID.randomUUID()),
+                        TestingExecutionGraphCache.newBuilder().build(),
+                        new TestingFatalErrorHandler())) {
+
+            webMonitorEndpoint.start();
+
+            HttpURLConnection connection =
+                    (HttpURLConnection)
+                            new URI(
+                                            "http",
+                                            null,
+                                            "localhost",
+                                            webMonitorEndpoint.getServerAddress().getPort(),
+                                            JobManagerAuthenticatedUserHeaders.URL,
+                                            null,
+                                            null)
+                                    .toURL()
+                                    .openConnection();
+            connection.setRequestMethod("GET");
+
+            assertThat(connection.getResponseCode()).isEqualTo(200);
+            assertThat(
+                            new String(
+                                    connection.getInputStream().readAllBytes(),
+                                    StandardCharsets.UTF_8))
+                    .contains("\"authenticated\":false");
+        } finally {
+            ExecutorUtils.gracefulShutdown(timeout, TimeUnit.MILLISECONDS, executor);
+        }
+    }
+
+    @Test
+    void failsFastForInvalidKerberosWebAuthenticationConfiguration() throws Exception {
+        final Configuration configuration = new Configuration();
+        configuration.set(RestOptions.ADDRESS, "localhost");
+        configuration.set(
+                WebOptions.AUTHENTICATION_TYPE, WebOptions.WebAuthenticationType.KERBEROS);
+        final ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
+        final long timeout = 10000L;
+
+        try {
+            assertThatThrownBy(
+                            () ->
+                                    new WebMonitorEndpoint<>(
+                                            CompletableFuture::new,
+                                            configuration,
+                                            RestHandlerConfiguration.fromConfiguration(
+                                                    configuration),
+                                            CompletableFuture::new,
+                                            NoOpTransientBlobService.INSTANCE,
+                                            executor,
+                                            VoidMetricFetcher.INSTANCE,
+                                            new StandaloneLeaderElection(UUID.randomUUID()),
+                                            TestingExecutionGraphCache.newBuilder().build(),
+                                            new TestingFatalErrorHandler()))
+                    .isInstanceOf(ConfigurationException.class)
+                    .hasMessageContaining(WebOptions.AUTHENTICATION_KERBEROS_PRINCIPAL.key());
         } finally {
             ExecutorUtils.gracefulShutdown(timeout, TimeUnit.MILLISECONDS, executor);
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/security/JobManagerAuthenticatedUserHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/security/JobManagerAuthenticatedUserHandlerTest.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.webmonitor.security;
+
+import org.apache.flink.runtime.rest.handler.router.RouteResult;
+import org.apache.flink.runtime.rest.handler.router.RoutedRequest;
+
+import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandlerAdapter;
+import org.apache.flink.shaded.netty4.io.netty.channel.embedded.EmbeddedChannel;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.DefaultFullHttpRequest;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.FullHttpRequest;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpHeaderNames;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpMethod;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponse;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpVersion;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.LastHttpContent;
+import org.apache.flink.shaded.netty4.io.netty.util.ReferenceCountUtil;
+
+import org.apache.hadoop.security.authentication.client.AuthenticatedURL;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link JobManagerAuthenticatedUserHandler}. */
+class JobManagerAuthenticatedUserHandlerTest {
+
+    private static final Clock NOW = Clock.fixed(Instant.ofEpochMilli(10_000L), ZoneOffset.UTC);
+    private static final byte[] SECRET = "secret".getBytes(StandardCharsets.UTF_8);
+
+    @Test
+    void shouldReturnUnauthenticatedResponseWhenAuthenticationIsDisabled() {
+        EmbeddedChannel channel = new EmbeddedChannel(new JobManagerAuthenticatedUserHandler());
+        DefaultFullHttpRequest request =
+                new DefaultFullHttpRequest(
+                        HttpVersion.HTTP_1_1,
+                        HttpMethod.GET,
+                        JobManagerAuthenticatedUserHeaders.URL);
+
+        try {
+            assertThat(channel.writeInbound(routedRequest(request))).isFalse();
+
+            HttpResponse response = channel.readOutbound();
+            assertThat(response.status()).isEqualTo(HttpResponseStatus.OK);
+            assertThat(response.headers().get(HttpHeaderNames.CACHE_CONTROL)).isEqualTo("no-store");
+            ByteBuf content = channel.readOutbound();
+            LastHttpContent lastContent = channel.readOutbound();
+            try {
+                assertThat(content.toString(StandardCharsets.UTF_8))
+                        .contains("\"authenticated\":false");
+                assertThat(lastContent).isSameAs(LastHttpContent.EMPTY_LAST_CONTENT);
+            } finally {
+                ReferenceCountUtil.release(content);
+                ReferenceCountUtil.release(lastContent);
+            }
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void shouldReturnAuthenticatedUserFromCurrentRequest() {
+        JobManagerAuthenticationTokenSigner signer =
+                new JobManagerAuthenticationTokenSigner(SECRET, Duration.ofHours(1), NOW);
+        JobManagerAuthenticatedUserHandler authenticatedUserHandler =
+                new JobManagerAuthenticatedUserHandler();
+        EmbeddedChannel channel =
+                new EmbeddedChannel(
+                        new JobManagerWebAuthenticationHandler(
+                                authorization ->
+                                        JobManagerSpnegoAuthenticationResult.challenge("Negotiate"),
+                                signer,
+                                "/",
+                                false,
+                                Collections.emptyMap()),
+                        new ChannelInboundHandlerAdapter() {
+                            @Override
+                            public void channelRead(ChannelHandlerContext ctx, Object msg)
+                                    throws Exception {
+                                if (msg instanceof FullHttpRequest) {
+                                    authenticatedUserHandler.channelRead(
+                                            ctx, routedRequest((FullHttpRequest) msg));
+                                } else {
+                                    super.channelRead(ctx, msg);
+                                }
+                            }
+                        });
+        DefaultFullHttpRequest request =
+                new DefaultFullHttpRequest(
+                        HttpVersion.HTTP_1_1,
+                        HttpMethod.GET,
+                        JobManagerAuthenticatedUserHeaders.URL);
+        request.headers()
+                .set(
+                        HttpHeaderNames.COOKIE,
+                        AuthenticatedURL.AUTH_COOKIE
+                                + "=\""
+                                + signer.signToken("alice", "alice@EXAMPLE.COM")
+                                + "\"");
+
+        try {
+            assertThat(channel.writeInbound(request)).isFalse();
+
+            HttpResponse response = channel.readOutbound();
+            assertThat(response.status()).isEqualTo(HttpResponseStatus.OK);
+            ByteBuf content = channel.readOutbound();
+            LastHttpContent lastContent = channel.readOutbound();
+            try {
+                assertThat(content.toString(StandardCharsets.UTF_8))
+                        .contains("\"authenticated\":true")
+                        .contains("\"user\":\"alice\"")
+                        .contains("\"principal\":\"alice@EXAMPLE.COM\"")
+                        .contains(
+                                "\"type\":\""
+                                        + JobManagerAuthenticationTokenSigner.TOKEN_TYPE_KERBEROS
+                                        + "\"");
+                assertThat(lastContent).isSameAs(LastHttpContent.EMPTY_LAST_CONTENT);
+            } finally {
+                ReferenceCountUtil.release(content);
+                ReferenceCountUtil.release(lastContent);
+            }
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    private static RoutedRequest<Object> routedRequest(FullHttpRequest request) {
+        return new RoutedRequest<>(
+                new RouteResult<>(
+                        request.uri(),
+                        request.uri(),
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        new JobManagerAuthenticatedUserHandler()),
+                request);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/security/JobManagerAuthenticationTokenSignerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/security/JobManagerAuthenticationTokenSignerTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.webmonitor.security;
+
+import org.apache.hadoop.security.authentication.server.AuthenticationToken;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link JobManagerAuthenticationTokenSigner}. */
+class JobManagerAuthenticationTokenSignerTest {
+
+    private static final byte[] SECRET = "shared-secret".getBytes(StandardCharsets.UTF_8);
+    private static final Clock NOW = Clock.fixed(Instant.ofEpochMilli(10_000L), ZoneOffset.UTC);
+
+    @Test
+    void shouldSignAndVerifyAuthenticationToken() {
+        JobManagerAuthenticationTokenSigner signer = signer(NOW, Duration.ofHours(1));
+
+        Optional<AuthenticationToken> token =
+                signer.verifyToken(signer.signToken("alice", "alice@EXAMPLE.COM"));
+
+        assertThat(token)
+                .hasValueSatisfying(
+                        authenticationToken -> {
+                            assertThat(authenticationToken.getUserName()).isEqualTo("alice");
+                            assertThat(authenticationToken.getName())
+                                    .isEqualTo("alice@EXAMPLE.COM");
+                            assertThat(authenticationToken.getType())
+                                    .isEqualTo(
+                                            JobManagerAuthenticationTokenSigner
+                                                    .TOKEN_TYPE_KERBEROS);
+                        });
+    }
+
+    @Test
+    void shouldRejectInvalidSignature() {
+        JobManagerAuthenticationTokenSigner signer = signer(NOW, Duration.ofHours(1));
+        String signedToken = signer.signToken("alice", "alice@EXAMPLE.COM");
+
+        assertThat(signer.verifyToken(signedToken + "tampered")).isEmpty();
+    }
+
+    @Test
+    void shouldRejectExpiredToken() {
+        JobManagerAuthenticationTokenSigner signer = signer(NOW, Duration.ofMillis(1));
+        String signedToken = signer.signToken("alice", "alice@EXAMPLE.COM");
+        JobManagerAuthenticationTokenSigner verifier =
+                signer(Clock.offset(NOW, Duration.ofMillis(2)), Duration.ofMillis(1));
+
+        assertThat(verifier.verifyToken(signedToken)).isEmpty();
+    }
+
+    @Test
+    void shouldAcceptQuotedCookieValue() {
+        JobManagerAuthenticationTokenSigner signer = signer(NOW, Duration.ofHours(1));
+        String signedToken = signer.signToken("alice", "alice@EXAMPLE.COM");
+
+        assertThat(signer.verifyToken("\"" + signedToken + "\"")).isPresent();
+    }
+
+    private static JobManagerAuthenticationTokenSigner signer(Clock clock, Duration tokenValidity) {
+        return new JobManagerAuthenticationTokenSigner(SECRET, tokenValidity, clock);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/security/JobManagerWebAuthenticationConfigTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/security/JobManagerWebAuthenticationConfigTest.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.webmonitor.security;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.configuration.WebOptions;
+import org.apache.flink.configuration.WebOptions.WebAuthenticationType;
+import org.apache.flink.util.ConfigurationException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link JobManagerWebAuthenticationConfig}. */
+class JobManagerWebAuthenticationConfigTest {
+
+    @TempDir private Path tempDir;
+
+    @Test
+    void shouldReturnEmptyConfigWhenAuthenticationIsDisabled() throws Exception {
+        assertThat(JobManagerWebAuthenticationConfig.fromConfiguration(new Configuration()))
+                .isEmpty();
+    }
+
+    @Test
+    void shouldRejectInvalidAuthenticationType() {
+        Configuration configuration = new Configuration();
+        configuration.setString(WebOptions.AUTHENTICATION_TYPE.key(), "BASIC");
+
+        assertThatThrownBy(() -> JobManagerWebAuthenticationConfig.fromConfiguration(configuration))
+                .isInstanceOf(ConfigurationException.class)
+                .hasMessageContaining(WebOptions.AUTHENTICATION_TYPE.key());
+    }
+
+    @Test
+    void shouldRequirePrincipalWhenKerberosIsEnabled() throws Exception {
+        Configuration configuration = kerberosConfiguration();
+        configuration.set(WebOptions.AUTHENTICATION_KERBEROS_KEYTAB, createKeytab().toString());
+
+        assertThatThrownBy(() -> JobManagerWebAuthenticationConfig.fromConfiguration(configuration))
+                .isInstanceOf(ConfigurationException.class)
+                .hasMessageContaining(WebOptions.AUTHENTICATION_KERBEROS_PRINCIPAL.key());
+    }
+
+    @Test
+    void shouldRequireKeytabWhenKerberosIsEnabled() {
+        Configuration configuration = kerberosConfiguration();
+        configuration.set(
+                WebOptions.AUTHENTICATION_KERBEROS_PRINCIPAL, "HTTP/localhost@EXAMPLE.COM");
+
+        assertThatThrownBy(() -> JobManagerWebAuthenticationConfig.fromConfiguration(configuration))
+                .isInstanceOf(ConfigurationException.class)
+                .hasMessageContaining(WebOptions.AUTHENTICATION_KERBEROS_KEYTAB.key());
+    }
+
+    @Test
+    void shouldResolveHostPlaceholderInPrincipalFromRestAddress() throws Exception {
+        Configuration configuration = validKerberosConfiguration();
+        configuration.set(WebOptions.AUTHENTICATION_KERBEROS_PRINCIPAL, "HTTP/_HOST@EXAMPLE.COM");
+        configuration.set(RestOptions.ADDRESS, "localhost");
+
+        JobManagerWebAuthenticationConfig config =
+                JobManagerWebAuthenticationConfig.fromConfiguration(configuration).orElseThrow();
+
+        assertThat(config.getKerberosPrincipal())
+                .startsWith("HTTP/")
+                .endsWith("@EXAMPLE.COM")
+                .doesNotContain("_HOST");
+    }
+
+    @Test
+    void shouldResolveHostPlaceholderFromBindAddressWhenRestAddressIsWildcard() throws Exception {
+        Configuration configuration = validKerberosConfiguration();
+        configuration.set(WebOptions.AUTHENTICATION_KERBEROS_PRINCIPAL, "HTTP/_HOST@EXAMPLE.COM");
+        configuration.set(RestOptions.ADDRESS, "0.0.0.0");
+        configuration.set(RestOptions.BIND_ADDRESS, "localhost");
+
+        JobManagerWebAuthenticationConfig config =
+                JobManagerWebAuthenticationConfig.fromConfiguration(configuration).orElseThrow();
+
+        assertThat(config.getKerberosPrincipal())
+                .startsWith("HTTP/")
+                .endsWith("@EXAMPLE.COM")
+                .doesNotContain("_HOST")
+                .doesNotContain("0.0.0.0");
+    }
+
+    @Test
+    void shouldAllowWildcardPrincipal() throws Exception {
+        Configuration configuration = validKerberosConfiguration();
+        configuration.set(WebOptions.AUTHENTICATION_KERBEROS_PRINCIPAL, "*");
+
+        JobManagerWebAuthenticationConfig config =
+                JobManagerWebAuthenticationConfig.fromConfiguration(configuration).orElseThrow();
+
+        assertThat(config.getKerberosPrincipal()).isEqualTo("*");
+    }
+
+    @Test
+    void shouldUseDefaultNameRules() throws Exception {
+        JobManagerWebAuthenticationConfig config =
+                JobManagerWebAuthenticationConfig.fromConfiguration(validKerberosConfiguration())
+                        .orElseThrow();
+
+        assertThat(config.getKerberosNameRules()).isEqualTo("DEFAULT");
+    }
+
+    @Test
+    void shouldRejectNonHttpPrincipal() throws Exception {
+        Configuration configuration = validKerberosConfiguration();
+        configuration.set(
+                WebOptions.AUTHENTICATION_KERBEROS_PRINCIPAL, "flink/localhost@EXAMPLE.COM");
+
+        assertThatThrownBy(() -> JobManagerWebAuthenticationConfig.fromConfiguration(configuration))
+                .isInstanceOf(ConfigurationException.class)
+                .hasMessageContaining("must start with HTTP/");
+    }
+
+    @Test
+    void shouldRejectInvalidCookiePath() throws Exception {
+        Configuration configuration = validKerberosConfiguration();
+        configuration.set(WebOptions.AUTHENTICATION_COOKIE_PATH, "flink");
+
+        assertThatThrownBy(() -> JobManagerWebAuthenticationConfig.fromConfiguration(configuration))
+                .isInstanceOf(ConfigurationException.class)
+                .hasMessageContaining(WebOptions.AUTHENTICATION_COOKIE_PATH.key());
+    }
+
+    @Test
+    void shouldRejectNonPositiveTokenValidity() throws Exception {
+        Configuration configuration = validKerberosConfiguration();
+        configuration.set(WebOptions.AUTHENTICATION_TOKEN_VALIDITY, Duration.ZERO);
+
+        assertThatThrownBy(() -> JobManagerWebAuthenticationConfig.fromConfiguration(configuration))
+                .isInstanceOf(ConfigurationException.class)
+                .hasMessageContaining(WebOptions.AUTHENTICATION_TOKEN_VALIDITY.key());
+    }
+
+    @Test
+    void shouldRejectUnreadableKeytabPath() throws Exception {
+        Configuration configuration = kerberosConfiguration();
+        configuration.set(
+                WebOptions.AUTHENTICATION_KERBEROS_PRINCIPAL, "HTTP/localhost@EXAMPLE.COM");
+        configuration.set(
+                WebOptions.AUTHENTICATION_KERBEROS_KEYTAB,
+                tempDir.resolve("missing.keytab").toString());
+
+        assertThatThrownBy(() -> JobManagerWebAuthenticationConfig.fromConfiguration(configuration))
+                .isInstanceOf(ConfigurationException.class)
+                .hasMessageContaining(WebOptions.AUTHENTICATION_KERBEROS_KEYTAB.key());
+    }
+
+    @Test
+    void shouldRejectMultipleSignatureSecretSources() throws Exception {
+        Configuration configuration = validKerberosConfiguration();
+        configuration.set(WebOptions.AUTHENTICATION_SIGNATURE_SECRET, "secret");
+        configuration.set(
+                WebOptions.AUTHENTICATION_SIGNATURE_SECRET_FILE,
+                createSecretFile("secret").toString());
+
+        assertThatThrownBy(() -> JobManagerWebAuthenticationConfig.fromConfiguration(configuration))
+                .isInstanceOf(ConfigurationException.class)
+                .hasMessageContaining("Only one of");
+    }
+
+    @Test
+    void shouldLoadSignatureSecretFromFile() throws Exception {
+        Configuration configuration = validKerberosConfiguration();
+        configuration.set(
+                WebOptions.AUTHENTICATION_SIGNATURE_SECRET_FILE,
+                createSecretFile("shared-secret\n").toString());
+
+        JobManagerWebAuthenticationConfig config =
+                JobManagerWebAuthenticationConfig.fromConfiguration(configuration).orElseThrow();
+
+        assertThat(new String(config.getSignatureSecret(), StandardCharsets.UTF_8))
+                .isEqualTo("shared-secret");
+    }
+
+    private Configuration validKerberosConfiguration() throws Exception {
+        Configuration configuration = kerberosConfiguration();
+        configuration.set(
+                WebOptions.AUTHENTICATION_KERBEROS_PRINCIPAL, "HTTP/localhost@EXAMPLE.COM");
+        configuration.set(WebOptions.AUTHENTICATION_KERBEROS_KEYTAB, createKeytab().toString());
+        return configuration;
+    }
+
+    private static Configuration kerberosConfiguration() {
+        Configuration configuration = new Configuration();
+        configuration.set(WebOptions.AUTHENTICATION_TYPE, WebAuthenticationType.KERBEROS);
+        return configuration;
+    }
+
+    private Path createKeytab() throws Exception {
+        return Files.createFile(tempDir.resolve("test-" + System.nanoTime() + ".keytab"));
+    }
+
+    private Path createSecretFile(String secret) throws Exception {
+        Path secretFile = tempDir.resolve("secret-" + System.nanoTime());
+        return Files.write(secretFile, secret.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/security/JobManagerWebAuthenticationHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/security/JobManagerWebAuthenticationHandlerTest.java
@@ -1,0 +1,375 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.webmonitor.security;
+
+import org.apache.flink.configuration.Configuration;
+
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandler;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandlerAdapter;
+import org.apache.flink.shaded.netty4.io.netty.channel.embedded.EmbeddedChannel;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.DefaultFullHttpRequest;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.DefaultFullHttpResponse;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.FullHttpRequest;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.FullHttpResponse;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpHeaderNames;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpMethod;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpVersion;
+import org.apache.flink.shaded.netty4.io.netty.util.ReferenceCountUtil;
+
+import org.apache.hadoop.security.authentication.client.AuthenticatedURL;
+import org.apache.hadoop.security.authentication.client.AuthenticationException;
+import org.apache.hadoop.security.authentication.server.AuthenticationToken;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link JobManagerWebAuthenticationHandler}. */
+class JobManagerWebAuthenticationHandlerTest {
+
+    private static final byte[] SECRET = "secret".getBytes(StandardCharsets.UTF_8);
+    private static final Clock NOW = Clock.fixed(Instant.ofEpochMilli(10_000L), ZoneOffset.UTC);
+
+    @Test
+    void shouldNotCreateHandlerWhenAuthenticationIsDisabled() throws Exception {
+        assertThat(
+                        JobManagerWebAuthenticationHandler.createFactory(
+                                new Configuration(), Collections.emptyMap()))
+                .isEmpty();
+    }
+
+    @Test
+    void shouldChallengeUnauthenticatedRequest() {
+        EmbeddedChannel channel =
+                channel(
+                        authorization ->
+                                JobManagerSpnegoAuthenticationResult.challenge("Negotiate"));
+
+        channel.writeInbound(request());
+
+        FullHttpResponse response = channel.readOutbound();
+        try {
+            assertThat(response.status()).isEqualTo(HttpResponseStatus.UNAUTHORIZED);
+            assertThat(response.headers().get(HttpHeaderNames.WWW_AUTHENTICATE))
+                    .isEqualTo("Negotiate");
+            assertThat(response.headers().getInt(HttpHeaderNames.CONTENT_LENGTH)).isZero();
+            assertThat(response.headers().getAll(HttpHeaderNames.SET_COOKIE))
+                    .anySatisfy(
+                            cookie ->
+                                    assertThat(cookie)
+                                            .startsWith(AuthenticatedURL.AUTH_COOKIE + "=")
+                                            .contains("Max-Age=0")
+                                            .contains("HttpOnly"));
+        } finally {
+            response.release();
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void shouldRejectInvalidSpnegoToken() {
+        EmbeddedChannel channel =
+                channel(
+                        authorization -> {
+                            throw new AuthenticationException("bad token");
+                        });
+
+        FullHttpRequest request = request();
+        request.headers().set(HttpHeaderNames.AUTHORIZATION, "Negotiate invalid");
+        channel.writeInbound(request);
+
+        FullHttpResponse response = channel.readOutbound();
+        try {
+            assertThat(response.status()).isEqualTo(HttpResponseStatus.FORBIDDEN);
+            assertThat(response.headers().contains(HttpHeaderNames.WWW_AUTHENTICATE)).isFalse();
+            assertThat(response.headers().getAll(HttpHeaderNames.SET_COOKIE))
+                    .anySatisfy(
+                            cookie ->
+                                    assertThat(cookie)
+                                            .startsWith(AuthenticatedURL.AUTH_COOKIE + "=")
+                                            .contains("Max-Age=0"));
+        } finally {
+            response.release();
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void shouldPassThroughValidCookie() {
+        JobManagerAuthenticationTokenSigner signer = signer(NOW, Duration.ofHours(1));
+        EmbeddedChannel channel =
+                channel(
+                        authorization ->
+                                JobManagerSpnegoAuthenticationResult.challenge("Negotiate"),
+                        signer,
+                        false,
+                        Collections.emptyMap());
+
+        FullHttpRequest request = request();
+        request.headers()
+                .set(
+                        HttpHeaderNames.COOKIE,
+                        AuthenticatedURL.AUTH_COOKIE
+                                + "=\""
+                                + signer.signToken("alice", "alice@EXAMPLE.COM")
+                                + "\"");
+        channel.writeInbound(request);
+
+        FullHttpRequest forwarded = channel.readInbound();
+        try {
+            assertThat(forwarded.uri()).isEqualTo("/jobs/overview");
+            assertThat((Object) channel.readOutbound()).isNull();
+        } finally {
+            forwarded.release();
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void shouldExposeAuthenticatedUserWhileHandlingRequestWithValidSignedCookie() {
+        AtomicReference<Optional<JobManagerAuthenticatedUser>> authenticatedUser =
+                new AtomicReference<>(Optional.empty());
+        JobManagerAuthenticationTokenSigner signer = signer(NOW, Duration.ofHours(1));
+        EmbeddedChannel channel =
+                channel(
+                        authorization ->
+                                JobManagerSpnegoAuthenticationResult.challenge("Negotiate"),
+                        signer,
+                        false,
+                        Collections.emptyMap(),
+                        new ChannelInboundHandlerAdapter() {
+                            @Override
+                            public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                                authenticatedUser.set(
+                                        JobManagerWebAuthenticationHandler.getAuthenticatedUser(
+                                                ctx));
+                                ReferenceCountUtil.release(msg);
+                            }
+                        });
+
+        FullHttpRequest request = request();
+        request.headers()
+                .set(
+                        HttpHeaderNames.COOKIE,
+                        AuthenticatedURL.AUTH_COOKIE
+                                + "=\""
+                                + signer.signToken("alice", "alice@EXAMPLE.COM")
+                                + "\"");
+        channel.writeInbound(request);
+
+        try {
+            assertThat(authenticatedUser.get())
+                    .hasValueSatisfying(
+                            user -> {
+                                assertThat(user.getUserName()).isEqualTo("alice");
+                                assertThat(user.getPrincipal()).isEqualTo("alice@EXAMPLE.COM");
+                                assertThat(user.getType())
+                                        .isEqualTo(
+                                                JobManagerAuthenticationTokenSigner
+                                                        .TOKEN_TYPE_KERBEROS);
+                            });
+            assertThat(
+                            JobManagerWebAuthenticationHandler.getAuthenticatedUser(
+                                    channel.pipeline().firstContext()))
+                    .isEmpty();
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void shouldIgnoreExpiredCookieAndRestartChallenge() {
+        JobManagerAuthenticationTokenSigner signer = signer(NOW, Duration.ofMillis(1));
+        String expiredToken = signer.signToken("alice", "alice@EXAMPLE.COM");
+        EmbeddedChannel channel =
+                channel(
+                        authorization ->
+                                JobManagerSpnegoAuthenticationResult.challenge("Negotiate"),
+                        signer(Clock.offset(NOW, Duration.ofMillis(2)), Duration.ofMillis(1)),
+                        false,
+                        Collections.emptyMap());
+
+        FullHttpRequest request = request();
+        request.headers()
+                .set(
+                        HttpHeaderNames.COOKIE,
+                        AuthenticatedURL.AUTH_COOKIE + "=\"" + expiredToken + "\"");
+        channel.writeInbound(request);
+
+        FullHttpResponse response = channel.readOutbound();
+        try {
+            assertThat(response.status()).isEqualTo(HttpResponseStatus.UNAUTHORIZED);
+            assertThat(response.headers().get(HttpHeaderNames.WWW_AUTHENTICATE))
+                    .isEqualTo("Negotiate");
+        } finally {
+            response.release();
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void shouldIssueCookieAfterSuccessfulSpnegoAuthentication() {
+        AtomicReference<Optional<JobManagerAuthenticatedUser>> authenticatedUser =
+                new AtomicReference<>(Optional.empty());
+        EmbeddedChannel channel =
+                channel(
+                        authorization ->
+                                JobManagerSpnegoAuthenticationResult.authenticated(
+                                        new AuthenticationToken(
+                                                "alice",
+                                                "alice@EXAMPLE.COM",
+                                                JobManagerAuthenticationTokenSigner
+                                                        .TOKEN_TYPE_KERBEROS),
+                                        "Negotiate server-token"),
+                        signer(NOW, Duration.ofHours(1)),
+                        false,
+                        Collections.emptyMap(),
+                        new ChannelInboundHandlerAdapter() {
+                            @Override
+                            public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                                authenticatedUser.set(
+                                        JobManagerWebAuthenticationHandler.getAuthenticatedUser(
+                                                ctx));
+                                ReferenceCountUtil.release(msg);
+                            }
+                        });
+
+        FullHttpRequest request = request();
+        request.headers().set(HttpHeaderNames.AUTHORIZATION, "Negotiate client-token");
+        channel.writeInbound(request);
+
+        channel.writeOutbound(
+                new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK));
+        FullHttpResponse response = channel.readOutbound();
+        try {
+            assertThat(authenticatedUser.get())
+                    .hasValueSatisfying(
+                            user -> {
+                                assertThat(user.getUserName()).isEqualTo("alice");
+                                assertThat(user.getPrincipal()).isEqualTo("alice@EXAMPLE.COM");
+                                assertThat(user.getType())
+                                        .isEqualTo(
+                                                JobManagerAuthenticationTokenSigner
+                                                        .TOKEN_TYPE_KERBEROS);
+                            });
+            assertThat(response.headers().get(HttpHeaderNames.SET_COOKIE))
+                    .contains(AuthenticatedURL.AUTH_COOKIE + "=\"")
+                    .contains("; Path=/")
+                    .contains("; HttpOnly");
+            assertThat(response.headers().get(HttpHeaderNames.WWW_AUTHENTICATE))
+                    .isEqualTo("Negotiate server-token");
+        } finally {
+            response.release();
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void shouldMarkAuthenticationCookieSecureWhenSslIsEnabled() {
+        EmbeddedChannel channel =
+                channel(
+                        authorization ->
+                                JobManagerSpnegoAuthenticationResult.authenticated(
+                                        new AuthenticationToken(
+                                                "alice",
+                                                "alice@EXAMPLE.COM",
+                                                JobManagerAuthenticationTokenSigner
+                                                        .TOKEN_TYPE_KERBEROS),
+                                        null),
+                        signer(NOW, Duration.ofHours(1)),
+                        true,
+                        Collections.emptyMap());
+
+        FullHttpRequest request = request();
+        request.headers().set(HttpHeaderNames.AUTHORIZATION, "Negotiate client-token");
+        channel.writeInbound(request);
+        FullHttpRequest forwarded = channel.readInbound();
+        forwarded.release();
+
+        channel.writeOutbound(
+                new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK));
+        FullHttpResponse response = channel.readOutbound();
+        try {
+            assertThat(response.headers().get(HttpHeaderNames.SET_COOKIE)).contains("; Secure");
+        } finally {
+            response.release();
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void shouldIncludeConfiguredResponseHeadersInChallenge() {
+        EmbeddedChannel channel =
+                channel(
+                        authorization ->
+                                JobManagerSpnegoAuthenticationResult.challenge("Negotiate"),
+                        signer(NOW, Duration.ofHours(1)),
+                        false,
+                        Collections.singletonMap("Access-Control-Allow-Origin", "example.com"));
+
+        channel.writeInbound(request());
+
+        FullHttpResponse response = channel.readOutbound();
+        try {
+            assertThat(response.headers().get("Access-Control-Allow-Origin"))
+                    .isEqualTo("example.com");
+        } finally {
+            response.release();
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    private static EmbeddedChannel channel(SpnegoAuthenticator authenticator) {
+        return channel(
+                authenticator, signer(NOW, Duration.ofHours(1)), false, Collections.emptyMap());
+    }
+
+    private static EmbeddedChannel channel(
+            SpnegoAuthenticator authenticator,
+            JobManagerAuthenticationTokenSigner signer,
+            boolean secureCookie,
+            Map<String, String> responseHeaders,
+            ChannelHandler... additionalHandlers) {
+        ChannelHandler[] handlers = new ChannelHandler[additionalHandlers.length + 1];
+        handlers[0] =
+                new JobManagerWebAuthenticationHandler(
+                        authenticator, signer, "/", secureCookie, responseHeaders);
+        System.arraycopy(additionalHandlers, 0, handlers, 1, additionalHandlers.length);
+        return new EmbeddedChannel(handlers);
+    }
+
+    private static JobManagerAuthenticationTokenSigner signer(Clock clock, Duration tokenValidity) {
+        return new JobManagerAuthenticationTokenSigner(SECRET, tokenValidity, clock);
+    }
+
+    private static FullHttpRequest request() {
+        return new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/jobs/overview");
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/security/JobManagerWebSpnegoITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/security/JobManagerWebSpnegoITCase.java
@@ -1,0 +1,290 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.webmonitor.security;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.configuration.WebOptions;
+import org.apache.flink.configuration.WebOptions.WebAuthenticationType;
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
+import org.apache.flink.runtime.rest.util.TestMessageHeaders;
+import org.apache.flink.runtime.rest.util.TestRestHandler;
+import org.apache.flink.runtime.rest.util.TestRestServerEndpoint;
+import org.apache.flink.runtime.security.KerberosUtils;
+import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.TestingRestfulGateway;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.apache.hadoop.minikdc.MiniKdc;
+import org.apache.hadoop.security.authentication.client.AuthenticatedURL;
+import org.apache.hadoop.security.authentication.util.KerberosUtil;
+import org.ietf.jgss.GSSContext;
+import org.ietf.jgss.GSSManager;
+import org.ietf.jgss.GSSName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.security.auth.Subject;
+import javax.security.auth.login.AppConfigurationEntry;
+import javax.security.auth.login.LoginContext;
+
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.PrivilegedExceptionAction;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Integration tests for JobManager web SPNEGO authentication. */
+class JobManagerWebSpnegoITCase {
+
+    private static final MediaType JSON = MediaType.parse("application/json");
+    private static final String HOST = "localhost";
+    private static final String CLIENT_PRINCIPAL_NAME = "alice";
+    private static final String HTTP_SERVICE_PRINCIPAL_NAME = "HTTP/" + HOST;
+
+    @Test
+    void shouldRequireSpnegoAndAllowKerberosClient(@TempDir Path tempDir) throws Exception {
+        Properties previousProperties = rememberKerberosProperties();
+        MiniKdc kdc = null;
+        LoginContext loginContext = null;
+        try {
+            Path kdcDir = tempDir.resolve("kdc");
+            Files.createDirectories(kdcDir);
+            Properties kdcConf = MiniKdc.createConf();
+            kdcConf.setProperty(MiniKdc.KDC_BIND_ADDRESS, HOST);
+            kdc = new MiniKdc(kdcConf, kdcDir.toFile());
+            kdc.start();
+            System.setProperty(MiniKdc.JAVA_SECURITY_KRB5_CONF, kdc.getKrb5conf().toString());
+            System.setProperty("sun.security.krb5.disableReferrals", "true");
+
+            Path serverKeytab = tempDir.resolve("server.keytab");
+            Path clientKeytab = tempDir.resolve("client.keytab");
+            kdc.createPrincipal(serverKeytab.toFile(), HTTP_SERVICE_PRINCIPAL_NAME);
+            kdc.createPrincipal(clientKeytab.toFile(), CLIENT_PRINCIPAL_NAME);
+
+            Configuration configuration = createKerberosConfiguration(tempDir, serverKeytab);
+            JobManagerWebAuthenticationHandler.Factory authenticationHandlerFactory =
+                    JobManagerWebAuthenticationHandler.createFactory(
+                                    configuration, Collections.emptyMap())
+                            .orElseThrow();
+
+            GatewayRetriever<RestfulGateway> gatewayRetriever =
+                    () ->
+                            CompletableFuture.completedFuture(
+                                    new TestingRestfulGateway.Builder().build());
+            TestMessageHeaders<EmptyRequestBody, EmptyResponseBody, EmptyMessageParameters>
+                    jobsOverviewHeaders =
+                            TestMessageHeaders.emptyBuilder()
+                                    .setHttpMethod(HttpMethodWrapper.GET)
+                                    .setTargetRestEndpointURL("/jobs/overview")
+                                    .build();
+            TestRestHandler<
+                            RestfulGateway,
+                            EmptyRequestBody,
+                            EmptyResponseBody,
+                            EmptyMessageParameters>
+                    jobsOverviewHandler =
+                            new TestRestHandler<>(
+                                    gatewayRetriever,
+                                    jobsOverviewHeaders,
+                                    CompletableFuture.completedFuture(
+                                            EmptyResponseBody.getInstance()));
+
+            try (TestRestServerEndpoint endpoint =
+                    TestRestServerEndpoint.builder(configuration)
+                            .withEndpointSpecificChannelHandlerFactory(
+                                    authenticationHandlerFactory::createHandler)
+                            .withHandler(jobsOverviewHeaders, jobsOverviewHandler)
+                            .build()) {
+                endpoint.start();
+                String baseUrl = getBaseUrl(endpoint);
+
+                OkHttpClient httpClient = new OkHttpClient();
+                assertSpnegoChallenge(
+                        httpClient, new Request.Builder().url(baseUrl + "/jobs/overview"));
+                assertSpnegoChallenge(
+                        httpClient,
+                        new Request.Builder()
+                                .url(baseUrl + "/jars/upload")
+                                .post(RequestBody.create(JSON, "{}")));
+
+                loginContext =
+                        loginFromKeytab(CLIENT_PRINCIPAL_NAME + "@" + kdc.getRealm(), clientKeytab);
+                try (Response jobsOverviewResponse =
+                        spnegoRequest(
+                                httpClient,
+                                new Request.Builder().url(baseUrl + "/jobs/overview"),
+                                loginContext.getSubject())) {
+                    assertThat(jobsOverviewResponse.code()).isEqualTo(200);
+                    assertThat(jobsOverviewResponse.header("Set-Cookie"))
+                            .contains(AuthenticatedURL.AUTH_COOKIE + "=");
+                }
+            }
+        } finally {
+            if (loginContext != null) {
+                loginContext.logout();
+            }
+            if (kdc != null) {
+                kdc.stop();
+            }
+            restoreKerberosProperties(previousProperties);
+        }
+    }
+
+    private static Configuration createKerberosConfiguration(Path tempDir, Path serverKeytab) {
+        Configuration configuration = new Configuration();
+        configuration.set(RestOptions.BIND_PORT, "0");
+        configuration.set(RestOptions.BIND_ADDRESS, HOST);
+        configuration.set(RestOptions.ADDRESS, HOST);
+        configuration.set(WebOptions.UPLOAD_DIR, tempDir.resolve("uploads").toString());
+        configuration.set(WebOptions.AUTHENTICATION_TYPE, WebAuthenticationType.KERBEROS);
+        configuration.set(WebOptions.AUTHENTICATION_KERBEROS_PRINCIPAL, "*");
+        configuration.set(WebOptions.AUTHENTICATION_KERBEROS_KEYTAB, serverKeytab.toString());
+        configuration.set(WebOptions.AUTHENTICATION_SIGNATURE_SECRET, "shared-test-secret");
+        return configuration;
+    }
+
+    private static void assertSpnegoChallenge(OkHttpClient httpClient, Request.Builder builder)
+            throws Exception {
+        try (Response response = httpClient.newCall(builder.build()).execute()) {
+            assertThat(response.code()).isEqualTo(401);
+            assertThat(response.header("WWW-Authenticate")).isEqualTo("Negotiate");
+        }
+    }
+
+    private static Response spnegoRequest(
+            OkHttpClient httpClient, Request.Builder builder, Subject clientSubject)
+            throws Exception {
+        return Subject.doAs(
+                clientSubject,
+                (PrivilegedExceptionAction<Response>)
+                        () -> {
+                            GSSManager gssManager = GSSManager.getInstance();
+                            GSSName serverName =
+                                    gssManager.createName(
+                                            "HTTP@" + HOST, GSSName.NT_HOSTBASED_SERVICE);
+                            GSSContext gssContext =
+                                    gssManager.createContext(
+                                            serverName,
+                                            KerberosUtil.GSS_SPNEGO_MECH_OID,
+                                            null,
+                                            GSSContext.DEFAULT_LIFETIME);
+                            try {
+                                gssContext.requestMutualAuth(true);
+                                byte[] clientToken = new byte[0];
+                                for (int i = 0; i < 2; i++) {
+                                    byte[] outputToken =
+                                            gssContext.initSecContext(
+                                                    clientToken, 0, clientToken.length);
+                                    Request request =
+                                            builder.header(
+                                                            "Authorization",
+                                                            "Negotiate "
+                                                                    + Base64.getEncoder()
+                                                                            .encodeToString(
+                                                                                    outputToken))
+                                                    .build();
+                                    Response response = httpClient.newCall(request).execute();
+                                    if (response.code() != 401) {
+                                        return response;
+                                    }
+                                    String authenticateHeader =
+                                            response.header("WWW-Authenticate", "Negotiate");
+                                    response.close();
+                                    clientToken = decodeServerToken(authenticateHeader);
+                                }
+                                throw new IllegalStateException(
+                                        "SPNEGO authentication did not complete.");
+                            } finally {
+                                gssContext.dispose();
+                            }
+                        });
+    }
+
+    private static byte[] decodeServerToken(String authenticateHeader) {
+        String prefix = "Negotiate ";
+        if (!authenticateHeader.startsWith(prefix)) {
+            return new byte[0];
+        }
+        return Base64.getDecoder().decode(authenticateHeader.substring(prefix.length()));
+    }
+
+    private static LoginContext loginFromKeytab(String principal, Path keytab) throws Exception {
+        LoginContext loginContext =
+                new LoginContext(
+                        "client",
+                        null,
+                        null,
+                        new javax.security.auth.login.Configuration() {
+                            @Override
+                            public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
+                                return new AppConfigurationEntry[] {
+                                    KerberosUtils.keytabEntry(keytab.toString(), principal)
+                                };
+                            }
+                        });
+        loginContext.login();
+        return loginContext;
+    }
+
+    private static String getBaseUrl(TestRestServerEndpoint endpoint) {
+        InetSocketAddress serverAddress = endpoint.getServerAddress();
+        return "http://" + serverAddress.getHostString() + ":" + serverAddress.getPort();
+    }
+
+    private static Properties rememberKerberosProperties() {
+        Properties properties = new Properties();
+        remember(properties, MiniKdc.JAVA_SECURITY_KRB5_CONF);
+        remember(properties, "sun.security.krb5.disableReferrals");
+        return properties;
+    }
+
+    private static void remember(Properties properties, String key) {
+        String value = System.getProperty(key);
+        if (value != null) {
+            properties.setProperty(key, value);
+        }
+    }
+
+    private static void restoreKerberosProperties(Properties properties) {
+        restore(properties, MiniKdc.JAVA_SECURITY_KRB5_CONF);
+        restore(properties, "sun.security.krb5.disableReferrals");
+    }
+
+    private static void restore(Properties properties, String key) {
+        if (properties.containsKey(key)) {
+            System.setProperty(key, properties.getProperty(key));
+        } else {
+            System.clearProperty(key);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **ADH-7564**: SPNEGO authentication for Flink JobManager Web UI and REST endpoint.

The default behavior remains unchanged: authentication type is `NONE` unless explicitly enabled.

## Problem

Flink JobManager Web UI can be exposed on network interfaces without authentication.

## Changes

- Added SPNEGO authentication support for JobManager Web UI and REST endpoints.
- Protected all WebMonitor paths when Kerberos authentication is enabled, including dashboard assets, `/jobs`, `/jars/upload`, `/jars/:jarid/run`, cancel/rescale endpoints, and REST metadata paths.
- Added Hadoop-compatible `Authorization: Negotiate` / `WWW-Authenticate: Negotiate` flow.
- Added signed `hadoop.auth` cookies after successful SPNEGO negotiation.
- Added startup validation for required Kerberos principal/keytab options.
- Added support for `HTTP/_HOST@REALM` principal replacement and wildcard `*` keytab principal loading.
- Added optional shared cookie signing secret for multi-instance deployments.
- Added `/auth/user` JobManager endpoint and UI display of the authenticated user.
- Updated documentation with SPNEGO setup examples and exposure warnings.

## New Settings

### JobManager Web UI / REST

- `web.authentication.type`  
  Authentication mode. Default: `NONE`. Supported: `NONE`, `KERBEROS`.

- `web.authentication.kerberos.principal`  
  Kerberos HTTP service principal for SPNEGO. Required for `KERBEROS`. Supports `HTTP/_HOST@REALM` and `*`.

- `web.authentication.kerberos.keytab`  
  Keytab path for the JobManager Web UI SPNEGO principal. Required for `KERBEROS`.

- `web.authentication.kerberos.name-rules`  
  Kerberos auth-to-local rules. Default: `DEFAULT`.

- `web.authentication.token.validity`  
  Signed auth cookie validity. Default: `10 h`.

- `web.authentication.cookie.path`  
  Cookie path for `hadoop.auth`. Default: `/`.

- `web.authentication.signature.secret`  
  Inline shared cookie-signing secret.

- `web.authentication.signature.secret-file`  
  File containing shared cookie-signing secret.